### PR TITLE
fix(scraper): alerta quando seletor/layout do ML quebra

### DIFF
--- a/scrapper_mlb/services/product_service.py
+++ b/scrapper_mlb/services/product_service.py
@@ -6,12 +6,18 @@ from scrapper_mlb.services.url_builder import build_search_url
 
 #///////////
 
+# Acima desta fração de cards falhando, presume-se que o seletor/layout do ML
+# mudou (e não que sejam apenas cards patrocinados/placeholder esparsos).
+FAIL_RATIO_ALERT = 0.6
+
+
 def collect_products(url: str):
     html = fetch_html(url)
     soup = parse_html(html)
     nodes = find_product_nodes(soup)
 
     products = []
+    falhas = 0
 
     for item in nodes:
         try:
@@ -20,7 +26,16 @@ def collect_products(url: str):
         except ValueError:
             # Item não representa um produto válido
             # (card patrocinado, placeholder, layout alternativo, etc.)
+            falhas += 1
             continue
+
+    total = len(nodes)
+    if total and falhas / total >= FAIL_RATIO_ALERT:
+        print(
+            f"🚨 ALERTA: {falhas}/{total} cards falharam na extração "
+            f"({falhas / total:.0%}) — provável quebra de seletor/layout do ML. "
+            f"URL: {url}"
+        )
 
     return products
 

--- a/tests/unit/test_collect_products_alert.py
+++ b/tests/unit/test_collect_products_alert.py
@@ -1,0 +1,83 @@
+"""Cobre o alerta de quebra de seletor/layout (ponto #2 da issue #52).
+
+collect_products deve emitir alerta quando a maioria dos cards falha na
+extração, em vez de engolir tudo silenciosamente no `except ValueError`.
+"""
+import pytest
+
+from scrapper_mlb.services import product_service
+from scrapper_mlb.services.product_service import FAIL_RATIO_ALERT
+from tests.factories import ProductFactory
+
+
+@pytest.fixture
+def patch_pipeline(mocker):
+    """Neutraliza fetch/parse; cada nó é só um sentinela inteiro."""
+    mocker.patch.object(product_service, "fetch_html", return_value="<html>")
+    mocker.patch.object(product_service, "parse_html", return_value=object())
+
+    def _setup(n_nodes):
+        nodes = list(range(n_nodes))
+        mocker.patch.object(
+            product_service, "find_product_nodes", return_value=nodes
+        )
+        return nodes
+
+    return _setup
+
+
+def _build_side_effect(falhas: int):
+    """build_product: as `falhas` primeiras chamadas levantam ValueError."""
+    estado = {"chamadas": 0}
+
+    def _fake(item):
+        estado["chamadas"] += 1
+        if estado["chamadas"] <= falhas:
+            raise ValueError("seletor quebrado")
+        return ProductFactory()
+
+    return _fake
+
+
+@pytest.mark.unit
+def test_alerta_quando_maioria_falha(mocker, capsys, patch_pipeline):
+    patch_pipeline(10)
+    mocker.patch.object(
+        product_service, "build_product", side_effect=_build_side_effect(8)
+    )
+
+    produtos = product_service.collect_products("http://x")
+
+    out = capsys.readouterr().out
+    assert "🚨 ALERTA" in out
+    assert "8/10" in out
+    assert len(produtos) == 2
+
+
+@pytest.mark.unit
+def test_sem_alerta_quando_poucas_falhas(mocker, capsys, patch_pipeline):
+    patch_pipeline(10)
+    # 2/10 = 20% < 60%: cards patrocinados esparsos, sem alerta
+    mocker.patch.object(
+        product_service, "build_product", side_effect=_build_side_effect(2)
+    )
+
+    produtos = product_service.collect_products("http://x")
+
+    out = capsys.readouterr().out
+    assert "ALERTA" not in out
+    assert len(produtos) == 8
+
+
+@pytest.mark.unit
+def test_limiar_no_threshold_exato(mocker, capsys, patch_pipeline):
+    n = 10
+    falhas = int(n * FAIL_RATIO_ALERT)  # 6/10 == 60% -> alerta (>=)
+    patch_pipeline(n)
+    mocker.patch.object(
+        product_service, "build_product", side_effect=_build_side_effect(falhas)
+    )
+
+    product_service.collect_products("http://x")
+
+    assert "ALERTA" in capsys.readouterr().out


### PR DESCRIPTION
## Descrição

Corrige o ponto **#2** da issue #52.

`build_product` lança `ValueError` tanto para cards legítimos não-produto (patrocinado, placeholder) quanto para uma quebra de seletor que derruba **todos** os cards. Como `collect_products` fazia `except ValueError: continue` mudo, uma mudança de classe CSS do Mercado Livre fazia produtos sumirem silenciosamente, sem erro visível.

## Mudanças

- `collect_products` conta as falhas de extração por página.
- Emite alerta quando a fração de cards que falham passa de `FAIL_RATIO_ALERT` (60%), sinalizando provável quebra de seletor/layout do ML — com contagem, percentual e URL.

## Comportamento esperado

Operação normal (poucos cards patrocinados) segue silenciosa. Quebra de seletor (maioria/todos os cards falhando) vira alerta visível com a URL afetada.

## Checklist

- [x] Código segue o padrão do projeto (PT-BR, camadas)
- [x] Commit em Conventional Commits
- [x] Mudança coberta pela análise (Refs #52)
- [x] Sem mudança de API / breaking change
- [x] Sintaxe validada (`ast.parse`)
- [ ] Limiar (60%) ajustável conforme observação em produção
- [ ] Revisão de um mantenedor

Closes parcialmente #52 (apenas ponto #2).