### PR TITLE
fix(scraper): unifica detecção de bloqueio e protege a página de produto

### DIFF
--- a/scrapper_mlb/block_detection.py
+++ b/scrapper_mlb/block_detection.py
@@ -1,0 +1,29 @@
+"""Detecção unificada de página de bloqueio do Mercado Livre.
+
+Antes a lógica vivia duplicada em dois lugares com markers diferentes:
+- `http_client.is_blocked` (camada de listagem)
+- `update_service.is_block_page` (camada de página de produto)
+
+Aqui ficam os markers consolidados, num único ponto de manutenção.
+"""
+
+# Markers verificados como substring no HTML em minúsculas. Cobre tanto
+# páginas antifraude (captcha/tráfego suspeito) quanto telas de verificação
+# de conta. As classes CSS (.account-verification-header, .new-user-button)
+# aparecem como texto no markup, então o match por substring as cobre.
+BLOCK_MARKERS = [
+    "captcha",
+    "verify you are human",
+    "access denied",
+    "unusual traffic",
+    "suspicious_traffic",
+    "account-verification",
+    "new-user-button",
+    "olá! para continuar, acesse",
+]
+
+
+def is_blocked(html: str) -> bool:
+    """True se o HTML parece uma página de bloqueio/verificação do ML."""
+    html_lower = html.lower()
+    return any(marker in html_lower for marker in BLOCK_MARKERS)

--- a/scrapper_mlb/http_client.py
+++ b/scrapper_mlb/http_client.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import requests
 
+from scrapper_mlb.block_detection import is_blocked
 from scrapper_mlb.config import HEADERS
 
 
@@ -63,21 +64,6 @@ backoff = BackoffController()
 # 🔥 Sessão persistente
 session = requests.Session()
 session.headers.update(HEADERS)
-
-
-def is_blocked(html: str) -> bool:
-    html_lower = html.lower()
-
-    block_markers = [
-        "captcha",
-        "verify you are human",
-        "access denied",
-        "unusual traffic",
-        "suspicious_traffic",
-        "account-verification",
-    ]
-
-    return any(marker in html_lower for marker in block_markers)
 
 
 def fetch_html(url: str) -> str:

--- a/scrapper_mlb/product_page/service/update_service.py
+++ b/scrapper_mlb/product_page/service/update_service.py
@@ -1,28 +1,15 @@
 import os
-import time
 import requests
 from bs4 import BeautifulSoup
+from scrapper_mlb.block_detection import is_blocked
 from scrapper_mlb.config import HEADERS
+from scrapper_mlb.http_client import backoff, rate_limiter
 from scrapper_mlb.product_page.update_builder import build_product_page
 
 DEBUG_DIR = "debug_html"
 
 session = requests.Session()
 session.headers.update(HEADERS)
-
-
-def is_block_page(soup: BeautifulSoup) -> bool:
-    # Detecta bloqueio REAL
-    if soup.select_one(".account-verification-header"):
-        return True
-
-    if soup.select_one(".new-user-button"):
-        return True
-
-    if "Olá! Para continuar, acesse" in soup.get_text():
-        return True
-
-    return False
 
 
 def clean_url(url: str) -> str:
@@ -34,20 +21,24 @@ def _collect_once(url: str, produto_id: int):
     try:
         url = clean_url(url)
 
+        # 🔥 Mesmo rate limiter/backoff da listagem (politeness global)
+        rate_limiter.wait()
         response = session.get(url, timeout=15, allow_redirects=True)
 
         if response.status_code != 200:
             print(f"⚠️ Status inválido: {response.status_code}")
+            backoff.error()
+            return None
+
+        # 🔥 Detecção de bloqueio unificada (block_detection)
+        if is_blocked(response.text):
+            print(f"🚨 BLOQUEIO detectado para ID={produto_id}")
+            backoff.error()
             return None
 
         soup = BeautifulSoup(response.text, "html.parser")
-
-        # 🔥 Detecta bloqueio real
-        if is_block_page(soup):
-            print(f"🚨 BLOQUEIO detectado para ID={produto_id}")
-            return None
-
         page_data = build_product_page(soup)
+        backoff.success()
 
         # 🔥 Debug se não tiver preço
         if page_data.preco is None:
@@ -65,6 +56,7 @@ def _collect_once(url: str, produto_id: int):
 
     except requests.RequestException as e:
         print(f"⚠️ Erro de requisição: {e}")
+        backoff.error()
         return None
 
 
@@ -79,7 +71,9 @@ def collect_product_by_url(url: str, produto_id: int, retries: int = 1):
 
         if attempt < retries:
             print(f"🔁 Retry {attempt + 1}/{retries} para ID={produto_id}")
-            time.sleep(5)
+            # Espera com backoff exponencial (inflado pelo backoff.error()
+            # disparado no _collect_once em caso de erro/bloqueio).
+            backoff.wait()
 
     print(f"❌ Falha definitiva para ID={produto_id}")
     return None

--- a/tests/unit/test_block_detection.py
+++ b/tests/unit/test_block_detection.py
@@ -1,0 +1,39 @@
+import pytest
+
+from scrapper_mlb.block_detection import is_blocked
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "html",
+    [
+        "<html>Please solve the CAPTCHA</html>",
+        "<html>verify you are human</html>",
+        "<html>Access Denied</html>",
+        "<html>unusual traffic detected</html>",
+        "<div class='suspicious_traffic'></div>",
+        "<header class='account-verification-header'></header>",
+        "<button class='new-user-button'>x</button>",
+        "<p>Olá! Para continuar, acesse sua conta</p>",
+    ],
+)
+def test_is_blocked_detecta_markers(html):
+    assert is_blocked(html) is True
+
+
+@pytest.mark.unit
+def test_is_blocked_case_insensitive():
+    assert is_blocked("ACCOUNT-VERIFICATION") is True
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "html",
+    [
+        "<html><body>ui-search-layout__item produto normal</body></html>",
+        "<div class='andes-money-amount__fraction'>199</div>",
+        "",
+    ],
+)
+def test_is_blocked_pagina_normal(html):
+    assert is_blocked(html) is False

--- a/tests/unit/test_update_service_protection.py
+++ b/tests/unit/test_update_service_protection.py
@@ -1,0 +1,75 @@
+"""Garante que a página de produto usa rate limiter, backoff e detecção
+de bloqueio unificada (ponto #3 da issue #52)."""
+import pytest
+
+from scrapper_mlb.product_page.service import update_service
+from tests.factories import FakeResponseFactory, ProductPageDataFactory
+
+
+@pytest.fixture
+def patch_build(mocker):
+    """Evita parsing/IO real do build_product_page."""
+    return mocker.patch.object(
+        update_service,
+        "build_product_page",
+        return_value=ProductPageDataFactory(),
+    )
+
+
+@pytest.mark.unit
+def test_resposta_valida_usa_rate_limiter_e_success(mocker, patch_build):
+    wait = mocker.patch.object(update_service.rate_limiter, "wait")
+    success = mocker.patch.object(update_service.backoff, "success")
+    error = mocker.patch.object(update_service.backoff, "error")
+    mocker.patch.object(
+        update_service.session, "get", return_value=FakeResponseFactory()
+    )
+
+    result = update_service._collect_once("http://x/MLB1#frag", produto_id=1)
+
+    assert result is not None
+    wait.assert_called_once()          # rate limiter aplicado antes do GET
+    success.assert_called_once()       # backoff resetado na resposta válida
+    error.assert_not_called()
+
+
+@pytest.mark.unit
+def test_pagina_de_bloqueio_dispara_backoff_error(mocker, patch_build):
+    mocker.patch.object(update_service.rate_limiter, "wait")
+    error = mocker.patch.object(update_service.backoff, "error")
+    blocked = FakeResponseFactory(text="<html>resolva o CAPTCHA</html>")
+    mocker.patch.object(update_service.session, "get", return_value=blocked)
+
+    result = update_service._collect_once("http://x/MLB1", produto_id=1)
+
+    assert result is None
+    error.assert_called_once()
+    patch_build.assert_not_called()    # nem tenta parsear página bloqueada
+
+
+@pytest.mark.unit
+def test_status_invalido_dispara_backoff_error(mocker, patch_build):
+    mocker.patch.object(update_service.rate_limiter, "wait")
+    error = mocker.patch.object(update_service.backoff, "error")
+    mocker.patch.object(
+        update_service.session,
+        "get",
+        return_value=FakeResponseFactory(status_code=503),
+    )
+
+    result = update_service._collect_once("http://x/MLB1", produto_id=1)
+
+    assert result is None
+    error.assert_called_once()
+
+
+@pytest.mark.unit
+def test_retry_usa_backoff_wait(mocker):
+    # _collect_once sempre falha -> retry deve usar backoff.wait (não sleep fixo)
+    mocker.patch.object(update_service, "_collect_once", return_value=None)
+    backoff_wait = mocker.patch.object(update_service.backoff, "wait")
+
+    result = update_service.collect_product_by_url("http://x", 1, retries=2)
+
+    assert result is None
+    assert backoff_wait.call_count == 2


### PR DESCRIPTION
## Descrição

Corrige o ponto **#3** da issue #52.

Dois problemas relacionados:
1. **Detecção de bloqueio duplicada** — `http_client.is_blocked` (listagem) e `update_service.is_block_page` (página de produto) tinham lógicas e markers diferentes.
2. **Página de produto desprotegida** — `update_service` fazia `session.get` cru, sem rate limiter nem backoff. A camada mais exposta a ban era a menos protegida.

## Mudanças

- Novo módulo `scrapper_mlb/block_detection.py` concentra os markers de bloqueio (antifraude + verificação de conta). Substring no HTML em minúsculas; as classes CSS antigas (`.account-verification-header`, `.new-user-button`) viram markers de texto.
- `http_client.is_blocked` passa a re-exportar de `block_detection` (sem quebra de import).
- `update_service` remove `is_block_page` e reaproveita o `rate_limiter` e o `backoff` globais do `http_client`:
  - `rate_limiter.wait()` antes do GET (politeness global, mesmo intervalo da listagem)
  - `backoff.error()` em status inválido / bloqueio / `RequestException`
  - `backoff.success()` em resposta válida
  - retry usa `backoff.wait()` (exponencial) em vez de `sleep(5)` fixo

## Comportamento esperado

Página de produto agora respeita o mesmo ritmo da listagem e recua progressivamente sob erro/bloqueio. Detecção de bloqueio centralizada num só ponto de manutenção.

## Checklist

- [x] Código segue o padrão do projeto (PT-BR, camadas)
- [x] Commit em Conventional Commits
- [x] Mudança coberta pela análise (Refs #52)
- [x] Import `is_blocked` preservado (sem breaking change)
- [x] Sintaxe validada (`ast.parse`) nos 3 arquivos
- [ ] Markers de bloqueio revisados contra HTML real recente do ML
- [ ] Revisão de um mantenedor

Closes parcialmente #52 (apenas ponto #3).

> Nota: `rate_limiter`/`backoff` são singletons por processo; o ganho de pacing vale dentro do processo da página de produto. Combina bem com o PR de thread-safety (#53), mas é independente dele.