### PR TITLE
fix(affiliate): unifica create_driver e tira path do perfil do código

### DIFF
--- a/affiliate/driver.py
+++ b/affiliate/driver.py
@@ -1,17 +1,24 @@
+import os
+
 from selenium import webdriver
 from selenium.webdriver.chrome.options import Options
 
 
+# Perfil persistente do Chrome usado pelo worker de afiliado.
+# Configurável por ambiente para não ficar preso a um caminho de máquina.
+DEFAULT_PROFILE_DIR = os.path.expanduser("~/selenium-chromium-profile")
+
+
 def create_driver():
+    profile_dir = os.getenv("SELENIUM_PROFILE_DIR", DEFAULT_PROFILE_DIR)
+    profile_name = os.getenv("SELENIUM_PROFILE_NAME", "Default")
+
     options = Options()
 
-    options.add_argument(
-        "--user-data-dir=/home/leandro/selenium-chromium-profile"
-    )
-    options.add_argument("--profile-directory=Default")
+    options.add_argument(f"--user-data-dir={profile_dir}")
+    options.add_argument(f"--profile-directory={profile_name}")
 
     options.add_argument("--start-maximized")
     options.add_argument("--disable-blink-features=AutomationControlled")
 
     return webdriver.Chrome(options=options)
-    

--- a/affiliate/mlb_affiliate.py
+++ b/affiliate/mlb_affiliate.py
@@ -1,36 +1,20 @@
 import time
-import re
 
-from selenium import webdriver
-from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 
+from affiliate.driver import create_driver
 from affiliate.utils.affiliate_link import extrair_link_afiliado
 
 
 LINK_BUILDER_URL = "https://www.mercadolivre.com.br/afiliados/linkbuilder#hub"
 
 
-# =========================
-# Driver
-# =========================
-
-def create_driver():
-    options = Options()
-
-    # PROFILE CLONADO (não usar o do snap diretamente)
-    options.add_argument(
-        "--user-data-dir=/home/leandro/selenium-chromium-profile"
-    )
-    options.add_argument("--profile-directory=Default")
-
-    options.add_argument("--start-maximized")
-    options.add_argument("--disable-blink-features=AutomationControlled")
-
-    return webdriver.Chrome(options=options)
+# create_driver é reexportado de affiliate.driver (fonte única) para manter
+# compatibilidade com quem importa de affiliate.mlb_affiliate.
+__all__ = ["create_driver", "gerar_link_afiliado"]
 
 
 # =========================

--- a/tests/unit/test_affiliate_driver.py
+++ b/tests/unit/test_affiliate_driver.py
@@ -1,0 +1,56 @@
+"""Cobre a consolidação e a configuração por ambiente do create_driver
+(pontos #7 e #8 da issue #52)."""
+import pytest
+
+from affiliate import driver as driver_mod
+
+
+@pytest.fixture
+def fake_chrome(mocker):
+    """Evita subir Chrome real; devolve o Options capturado."""
+    chrome = mocker.patch.object(driver_mod.webdriver, "Chrome")
+
+    def _options():
+        # webdriver.Chrome(options=options) -> kwarg
+        _, kwargs = chrome.call_args
+        return kwargs["options"]
+
+    chrome.options = _options
+    return chrome
+
+
+@pytest.mark.unit
+def test_create_driver_usa_env_profile_dir(mocker, fake_chrome):
+    mocker.patch.dict(
+        "os.environ",
+        {"SELENIUM_PROFILE_DIR": "/custom/profile", "SELENIUM_PROFILE_NAME": "Bot"},
+    )
+
+    driver_mod.create_driver()
+
+    args = fake_chrome.options().arguments
+    assert "--user-data-dir=/custom/profile" in args
+    assert "--profile-directory=Bot" in args
+
+
+@pytest.mark.unit
+def test_create_driver_default_sem_env(mocker, fake_chrome):
+    mocker.patch.dict("os.environ", {}, clear=True)
+
+    driver_mod.create_driver()
+
+    args = fake_chrome.options().arguments
+    assert f"--user-data-dir={driver_mod.DEFAULT_PROFILE_DIR}" in args
+    assert "--profile-directory=Default" in args
+    # default derivado do HOME, não um caminho de máquina hardcoded
+    import os
+    assert driver_mod.DEFAULT_PROFILE_DIR == os.path.expanduser(
+        "~/selenium-chromium-profile"
+    )
+
+
+@pytest.mark.unit
+def test_mlb_affiliate_reexporta_mesmo_create_driver():
+    from affiliate.mlb_affiliate import create_driver as via_mlb
+
+    assert via_mlb is driver_mod.create_driver


### PR DESCRIPTION
## Descrição

Corrige os pontos **#7** e **#8** da issue #52.

- **#7**: `create_driver` estava duplicado em `affiliate/driver.py` e `affiliate/mlb_affiliate.py` (`affiliate/driver.py` órfão; `main.py` importava do `mlb_affiliate`).
- **#8**: ambos com o caminho do perfil do Chrome hardcoded (`/home/leandro/selenium-chromium-profile`) — não portável, quebra em outra máquina/container.

## Mudanças

- `affiliate/driver.py` vira a **fonte única** de `create_driver`.
- Diretório e nome do perfil passam a vir de `SELENIUM_PROFILE_DIR` / `SELENIUM_PROFILE_NAME`, com default derivado de `~` (HOME) via `os.path.expanduser`.
- `affiliate/mlb_affiliate.py` remove a cópia e **reexporta** `create_driver` de `affiliate.driver` (sem quebrar quem importava de lá). Remove imports de selenium agora não usados (`webdriver`, `Options`, `re`).
- `requirements`: `pytest-mock`, `factory-boy`.

## Testes

`tests/unit/test_affiliate_driver.py` (mock de `webdriver.Chrome`):
- config por env (`SELENIUM_PROFILE_DIR`/`NAME`)
- default derivado do HOME (sem path hardcoded)
- reexportação aponta para o mesmo objeto

## Checklist

- [x] Código segue o padrão do projeto (PT-BR, camadas)
- [x] Commit em Conventional Commits
- [x] Mudança coberta por testes (pytest + pytest-mock)
- [x] Sem breaking change de import (`create_driver` reexportado)
- [x] Sintaxe + importabilidade validadas
- [ ] Definir `SELENIUM_PROFILE_DIR` no `run_selenium.sh` / deploy se o default não servir
- [ ] Revisão de um mantenedor

Closes parcialmente #52 (pontos #7 e #8).