### PR TITLE
fix(affiliate): espera real pelo link e restart periódico do driver

### DIFF
--- a/affiliate/main.py
+++ b/affiliate/main.py
@@ -17,6 +17,10 @@ SLEEP_SEM_TRABALHO = 30
 SLEEP_ENTRE_LINKS = 3
 WAIT_TIMEOUT = 40
 
+# Reinicia o driver a cada N links para evitar degradação/vazamento de
+# memória do Chrome/Selenium em sessões longas.
+RESTART_DRIVER_EVERY = 100
+
 
 
 # =========================
@@ -34,6 +38,18 @@ def handle_shutdown(signum, frame):
 
 signal.signal(signal.SIGINT, handle_shutdown)
 signal.signal(signal.SIGTERM, handle_shutdown)
+
+
+def restart_driver(driver):
+    """Encerra o driver atual e devolve um novo driver + wait."""
+    try:
+        driver.quit()
+    except Exception:
+        pass
+
+    novo_driver = create_driver()
+    novo_wait = WebDriverWait(novo_driver, WAIT_TIMEOUT)
+    return novo_driver, novo_wait
 
 
 # =========================
@@ -56,6 +72,7 @@ def main():
     try:
         driver = create_driver()
         wait = WebDriverWait(driver, WAIT_TIMEOUT)
+        links_processados = 0
 
         while not shutdown_requested:
             # 🔁 conexão NOVA para cada batch
@@ -114,6 +131,16 @@ def main():
                         conn.commit()
 
                     time.sleep(SLEEP_ENTRE_LINKS)
+
+                    # 🔄 Reinicia o driver periodicamente (evita degradação
+                    # de memória do Selenium em sessões longas).
+                    links_processados += 1
+                    if links_processados % RESTART_DRIVER_EVERY == 0:
+                        print(
+                            f"🔄 {links_processados} links processados — "
+                            "reiniciando driver..."
+                        )
+                        driver, wait = restart_driver(driver)
 
             finally:
                 conn.close()

--- a/affiliate/mlb_affiliate.py
+++ b/affiliate/mlb_affiliate.py
@@ -4,12 +4,16 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
+from selenium.common.exceptions import TimeoutException
 
 from affiliate.driver import create_driver
 from affiliate.utils.affiliate_link import extrair_link_afiliado
 
 
 LINK_BUILDER_URL = "https://www.mercadolivre.com.br/afiliados/linkbuilder#hub"
+
+# Tempo máximo de espera pelo link afiliado aparecer no resultado.
+RESULT_TIMEOUT = 15
 
 
 # create_driver é reexportado de affiliate.driver (fonte única) para manter
@@ -58,17 +62,18 @@ def gerar_link_afiliado(driver, wait, produto_url: str) -> str | None:
         "arguments[0].scrollIntoView({block: 'center'});",
         botao_gerar
     )
-    time.sleep(0.5)
+    time.sleep(0.5)  # breve settle após scrollIntoView antes do click via JS
     driver.execute_script("arguments[0].click();", botao_gerar)
 
-    # espera curta
-    time.sleep(2)
+    # 🔍 espera o link afiliado realmente aparecer (em vez de sleep fixo)
+    try:
+        WebDriverWait(driver, RESULT_TIMEOUT).until(
+            lambda d: extrair_link_afiliado(d.page_source) is not None
+        )
+    except TimeoutException:
+        return None  # link não foi gerado a tempo
 
-    # 🔍 captura por regex (robusto)
-    html = driver.page_source
-    link = extrair_link_afiliado(html)
-
-    return link  # pode ser None se inválido
+    return extrair_link_afiliado(driver.page_source)
 
 
 # =========================

--- a/tests/unit/test_affiliate_worker.py
+++ b/tests/unit/test_affiliate_worker.py
@@ -1,0 +1,86 @@
+"""Cobre a robustez do worker de afiliado: espera real pelo link (#9) e
+restart periódico do driver (#10) da issue #52."""
+import pytest
+from selenium.common.exceptions import TimeoutException
+
+from affiliate import mlb_affiliate
+from affiliate import main as worker_main
+
+
+# ---------------------------------------------------------------------------
+# #9 — gerar_link_afiliado espera o link aparecer em vez de sleep fixo
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def driver(mocker):
+    return mocker.MagicMock(name="driver")
+
+
+@pytest.fixture(autouse=True)
+def no_sleep(mocker):
+    mocker.patch.object(mlb_affiliate.time, "sleep")
+
+
+@pytest.mark.unit
+def test_gerar_link_retorna_quando_link_aparece(mocker, driver):
+    wait = mocker.MagicMock(name="wait")
+    # WebDriverWait(...).until() devolve sem estourar -> link disponível
+    fake_wait = mocker.patch.object(mlb_affiliate, "WebDriverWait")
+    fake_wait.return_value.until.return_value = True
+    mocker.patch.object(
+        mlb_affiliate, "extrair_link_afiliado", return_value="http://aff/x"
+    )
+
+    link = mlb_affiliate.gerar_link_afiliado(driver, wait, "http://prod/MLB1")
+
+    assert link == "http://aff/x"
+    fake_wait.assert_called_once_with(driver, mlb_affiliate.RESULT_TIMEOUT)
+
+
+@pytest.mark.unit
+def test_gerar_link_retorna_none_em_timeout(mocker, driver):
+    wait = mocker.MagicMock(name="wait")
+    fake_wait = mocker.patch.object(mlb_affiliate, "WebDriverWait")
+    fake_wait.return_value.until.side_effect = TimeoutException()
+    mocker.patch.object(mlb_affiliate, "extrair_link_afiliado", return_value=None)
+
+    link = mlb_affiliate.gerar_link_afiliado(driver, wait, "http://prod/MLB1")
+
+    assert link is None
+
+
+# ---------------------------------------------------------------------------
+# #10 — restart_driver encerra o driver antigo e devolve um novo
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_restart_driver_encerra_e_recria(mocker):
+    old = mocker.MagicMock(name="old_driver")
+    novo = mocker.MagicMock(name="novo_driver")
+    create = mocker.patch.object(worker_main, "create_driver", return_value=novo)
+    mocker.patch.object(worker_main, "WebDriverWait", return_value="wait_obj")
+
+    driver, wait = worker_main.restart_driver(old)
+
+    old.quit.assert_called_once()
+    create.assert_called_once()
+    assert driver is novo
+    assert wait == "wait_obj"
+
+
+@pytest.mark.unit
+def test_restart_driver_ignora_erro_no_quit(mocker):
+    old = mocker.MagicMock(name="old_driver")
+    old.quit.side_effect = Exception("já morto")
+    novo = mocker.MagicMock(name="novo_driver")
+    mocker.patch.object(worker_main, "create_driver", return_value=novo)
+    mocker.patch.object(worker_main, "WebDriverWait", return_value="wait_obj")
+
+    driver, _ = worker_main.restart_driver(old)
+
+    assert driver is novo  # erro no quit não derruba o restart
+
+
+@pytest.mark.unit
+def test_restart_every_configurado():
+    assert worker_main.RESTART_DRIVER_EVERY > 0


### PR DESCRIPTION
## Descrição

Corrige os pontos **#9** e **#10** da issue #52.

- **#9**: `gerar_link_afiliado` usava `time.sleep(2)` fixo antes de ler o `page_source`. Em rede lenta isso capturava link vazio/`None`.
- **#10**: o worker usava um único driver para até 500 links sem restart; Selenium vaza memória em sessão longa → degradação/crash em batch grande.

## Mudanças

- `mlb_affiliate.gerar_link_afiliado`: substitui o `sleep(2)` final por `WebDriverWait` até `extrair_link_afiliado` encontrar o link (`RESULT_TIMEOUT=15`), retornando `None` em `TimeoutException`. Mantém o `sleep(0.5)` de settle antes do click via JS.
- `main`: novo `restart_driver(driver)` + reinício a cada `RESTART_DRIVER_EVERY` (100) links. Erro no `quit()` não derruba o restart.
- `requirements`: `pytest-mock`, `factory-boy`.

## Testes

`tests/unit/test_affiliate_worker.py`:
- `gerar_link_afiliado` retorna o link quando aparece e `None` em timeout
- `restart_driver` encerra o antigo, cria novo e ignora erro no `quit`
- `RESTART_DRIVER_EVERY` configurado

## Checklist

- [x] Código segue o padrão do projeto (PT-BR, camadas)
- [x] Commit em Conventional Commits
- [x] Mudança coberta por testes (pytest + pytest-mock)
- [x] Sem breaking change de assinatura
- [x] Sintaxe validada
- [ ] Ajustar `RESULT_TIMEOUT` / `RESTART_DRIVER_EVERY` conforme observação em produção
- [ ] Revisão de um mantenedor

> Toca `affiliate/mlb_affiliate.py` como o PR #56; ao mergear em sequência pode haver conflito trivial no bloco de imports.

Closes parcialmente #52 (pontos #9 e #10).