### PR TITLE
fix(scraper): rotação de User-Agent, debug sem corrida e page size configurável

### DIFF
--- a/scrapper_mlb/config.py
+++ b/scrapper_mlb/config.py
@@ -3,13 +3,34 @@ import os
 load_dotenv()
 URL_MLB_BASE = os.getenv("URL_MLB_BASE")
 
-HEADERS = {
-    "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36",
+import random
+
+# Pool de User-Agents para rotação — fingerprint estático único é fácil de
+# bloquear em escala. A cada request escolhe-se um UA aleatório.
+USER_AGENTS = [
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36",
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36",
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:123.0) Gecko/20100101 Firefox/123.0",
+    "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:122.0) Gecko/20100101 Firefox/122.0",
+]
+
+# Headers base (sem User-Agent, que é injetado por request via build_headers).
+BASE_HEADERS = {
     "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
     "Accept-Language": "pt-BR,pt;q=0.9,en;q=0.8",
     "Connection": "keep-alive",
     "Upgrade-Insecure-Requests": "1",
 }
+
+
+def build_headers() -> dict:
+    """Monta headers com um User-Agent aleatório do pool."""
+    return {**BASE_HEADERS, "User-Agent": random.choice(USER_AGENTS)}
+
+
+# Compat: HEADERS continua disponível (UA fixo do pool) para quem importa.
+HEADERS = {**BASE_HEADERS, "User-Agent": USER_AGENTS[0]}
 
 
 CATEGORIES = {

--- a/scrapper_mlb/http_client.py
+++ b/scrapper_mlb/http_client.py
@@ -1,3 +1,5 @@
+import hashlib
+import os
 import random
 import threading
 import time
@@ -6,14 +8,27 @@ from pathlib import Path
 import requests
 
 from scrapper_mlb.block_detection import is_blocked
-from scrapper_mlb.config import HEADERS
+from scrapper_mlb.config import HEADERS, build_headers
 
 
-DEBUG_PATH = Path("scrapper_mlb_debug.html")
+# Diretório de debug; cada URL gera um arquivo único para evitar corrida de
+# escrita entre as threads do ThreadPoolExecutor. Só grava se habilitado.
+DEBUG_DIR = Path("debug_html")
+DEBUG_ENABLED = os.getenv("SCRAPER_DEBUG_HTML", "").lower() in ("1", "true", "yes")
+_debug_lock = threading.Lock()
 
 MIN_HTML_SIZE = 50_000
 MAX_HTML_SIZE = 5_000_000
 MAX_RETRIES = 3
+
+
+def _save_debug(url: str, html: str) -> None:
+    if not DEBUG_ENABLED:
+        return
+    nome = hashlib.sha1(url.encode("utf-8")).hexdigest()[:12]
+    with _debug_lock:
+        DEBUG_DIR.mkdir(exist_ok=True)
+        (DEBUG_DIR / f"{nome}.html").write_text(html, encoding="utf-8")
 
 
 class BackoffController:
@@ -72,7 +87,8 @@ def fetch_html(url: str) -> str:
         rate_limiter.wait()
 
         try:
-            response = session.get(url, timeout=20)
+            # 🔄 User-Agent rotacionado por request (rotação de fingerprint)
+            response = session.get(url, timeout=20, headers=build_headers())
             status = response.status_code
             html = response.text
             size = len(html)
@@ -99,9 +115,8 @@ def fetch_html(url: str) -> str:
             if size > MAX_HTML_SIZE:
                 raise RuntimeError(f"HTML muito grande ({size})")
 
-            # 🔥 Salva debug
-            with open(DEBUG_PATH, "w", encoding="utf-8") as f:
-                f.write(html)
+            # 🔥 Salva debug (arquivo único por URL, sem corrida entre threads)
+            _save_debug(url, html)
 
             backoff.success()
             print("✅ HTML válido capturado")

--- a/scrapper_mlb/services/url_builder.py
+++ b/scrapper_mlb/services/url_builder.py
@@ -7,6 +7,10 @@ load_dotenv()
 
 URL_MLB_SEARCH_BASE = os.getenv("URL_MLB_SEARCH_BASE")
 
+# Tamanho da página de busca do ML (offset de paginação _Desde_). Hardcoded
+# antes; agora configurável caso o ML mude o page size.
+ML_PAGE_SIZE = int(os.getenv("ML_PAGE_SIZE", "48"))
+
 
 def build_search_url(
     query: str,
@@ -38,7 +42,7 @@ def build_search_url(
 
     # Paginação: _Desde_49
     if page > 1:
-        offset = (page - 1) * 48 + 1
+        offset = (page - 1) * ML_PAGE_SIZE + 1
         url += f"_Desde_{offset}"
 
     # Filtros adicionais

--- a/tests/unit/test_listing_hardening.py
+++ b/tests/unit/test_listing_hardening.py
@@ -1,0 +1,83 @@
+"""Cobre o hardening da camada de listagem: rotação de User-Agent (#5),
+debug sem corrida entre threads (#4) e page size configurável (#6)."""
+import importlib
+
+import pytest
+
+from scrapper_mlb import config
+from scrapper_mlb import http_client
+from scrapper_mlb.services import url_builder
+
+
+# ---------------------------------------------------------------------------
+# #5 — rotação de User-Agent
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_build_headers_usa_ua_do_pool():
+    headers = config.build_headers()
+    assert headers["User-Agent"] in config.USER_AGENTS
+    # mantém os headers base
+    assert headers["Accept-Language"].startswith("pt-BR")
+
+
+@pytest.mark.unit
+def test_build_headers_rotaciona(mocker):
+    # força UAs distintos em chamadas consecutivas
+    mocker.patch.object(
+        config.random, "choice", side_effect=[config.USER_AGENTS[0], config.USER_AGENTS[1]]
+    )
+    a = config.build_headers()["User-Agent"]
+    b = config.build_headers()["User-Agent"]
+    assert a != b
+
+
+# ---------------------------------------------------------------------------
+# #4 — debug não escreve por padrão e usa arquivo único por URL
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_save_debug_desabilitado_por_padrao(mocker, tmp_path):
+    mocker.patch.object(http_client, "DEBUG_ENABLED", False)
+    mocker.patch.object(http_client, "DEBUG_DIR", tmp_path)
+
+    http_client._save_debug("http://x/MLB1", "<html>")
+
+    assert list(tmp_path.glob("*.html")) == []  # nada escrito quando desabilitado
+
+
+@pytest.mark.unit
+def test_save_debug_arquivo_unico_por_url(mocker, tmp_path):
+    mocker.patch.object(http_client, "DEBUG_ENABLED", True)
+    mocker.patch.object(http_client, "DEBUG_DIR", tmp_path)
+
+    http_client._save_debug("http://x/MLB1", "<html>1</html>")
+    http_client._save_debug("http://x/MLB2", "<html>2</html>")
+
+    arquivos = list(tmp_path.glob("*.html"))
+    assert len(arquivos) == 2  # URLs diferentes -> arquivos diferentes
+
+
+# ---------------------------------------------------------------------------
+# #6 — page size configurável
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_offset_usa_page_size_default(monkeypatch):
+    monkeypatch.setenv("URL_MLB_SEARCH_BASE", "http://ml")
+    importlib.reload(url_builder)
+    url = url_builder.build_search_url("notebook", page=3)
+    # (3-1)*48 + 1 = 97
+    assert "_Desde_97" in url
+
+
+@pytest.mark.unit
+def test_offset_respeita_env_page_size(monkeypatch):
+    monkeypatch.setenv("URL_MLB_SEARCH_BASE", "http://ml")
+    monkeypatch.setenv("ML_PAGE_SIZE", "50")
+    importlib.reload(url_builder)
+    url = url_builder.build_search_url("notebook", page=2)
+    # (2-1)*50 + 1 = 51
+    assert "_Desde_51" in url
+    monkeypatch.delenv("ML_PAGE_SIZE", raising=False)
+    importlib.reload(url_builder)


### PR DESCRIPTION
## Descrição

Corrige os pontos **#4**, **#5** e **#6** da issue #52 (camada de listagem).

## Mudanças

### #5 — Rotação de User-Agent
Fingerprint estático (UA único hardcoded) é fácil de bloquear em escala.
- `config.py`: novo pool `USER_AGENTS` (5 UAs) + `BASE_HEADERS` + `build_headers()` (UA aleatório por chamada). `HEADERS` mantido por compat.
- `http_client.fetch_html`: passa `headers=build_headers()` em cada request.

### #4 — Debug sem corrida entre threads
`fetch_html` sobrescrevia um `scrapper_mlb_debug.html` global a cada página → corrida de escrita sob `ThreadPoolExecutor`.
- Grava arquivo **único por URL** (`debug_html/<hash>.html`), sob `threading.Lock`, e **só quando** `SCRAPER_DEBUG_HTML` está habilitado (default: desligado).

### #6 — Page size configurável
- `url_builder`: offset de paginação `48` hardcoded vira `ML_PAGE_SIZE` (env, default 48).

## Testes

`tests/unit/test_listing_hardening.py` (pytest + pytest-mock):
- UA do pool e rotação entre chamadas
- debug não escreve quando desabilitado; arquivo único por URL
- offset usa default e respeita `ML_PAGE_SIZE`

## Checklist

- [x] Código segue o padrão do projeto (PT-BR, camadas)
- [x] Commit em Conventional Commits
- [x] Mudança coberta por testes
- [x] `HEADERS` preservado (sem breaking change de import)
- [x] Sintaxe + importabilidade validadas
- [ ] Ampliar pool de UAs / habilitar `SCRAPER_DEBUG_HTML` em troubleshooting
- [ ] Revisão de um mantenedor

> Toca `http_client.py` como os PRs #53 (locks) e #55 (detecção de bloqueio); merge sequencial em `dev` pode ter conflito trivial.

Closes parcialmente #52 (pontos #4, #5, #6).