### PR TITLE
feat(ui): redesign dark premium + fixes Next 16

### DIFF
--- a/promoly-next/src/app/categoria/[slug]/page.tsx
+++ b/promoly-next/src/app/categoria/[slug]/page.tsx
@@ -7,7 +7,8 @@ import type { Metadata } from "next";
 const LIMIT = 12;
 
 const BASE_URL =
-  process.env.NEXT_PUBLIC_API_URL || "https://promoly-core.vercel.app";
+  process.env.NEXT_PUBLIC_API_URL ||
+  "https://promoly-core.vercel.app";
 
 /* =====================================================
    🔥 METADATA DINÂMICA
@@ -20,6 +21,7 @@ export async function generateMetadata({
   params: Promise<{ slug: string }>;
   searchParams: Promise<{ page?: string }>;
 }): Promise<Metadata> {
+
   const { slug } = await params;
   const resolvedSearchParams = await searchParams;
 
@@ -36,6 +38,7 @@ export async function generateMetadata({
     },
   };
 }
+
 
 /* =====================================================
    🔥 PAGE
@@ -121,8 +124,10 @@ export default async function CategoryPage(props: {
       },
     ],
   };
+
   return (
-    <div className="bg-[#000D34] min-h-screen">
+    <div className="bg-base min-h-screen">
+
       {/* 🔥 STRUCTURED DATA */}
       <script
         type="application/ld+json"
@@ -130,6 +135,7 @@ export default async function CategoryPage(props: {
           __html: JSON.stringify(itemListSchema),
         }}
       />
+
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{
@@ -137,41 +143,41 @@ export default async function CategoryPage(props: {
         }}
       />
 
-      <div className="max-w-7xl mx-auto px-6 py-16">
-        {/* ================= HERO HEADER ================= */}
-        <header className="mb-16 text-center">
-          <h1 className="text-3xl sm:text-4xl md:text-5xl font-extrabold text-[#9AEBA3] leading-tight">
-            Ofertas em <span className="text-[#F5F138] capitalize">{slug}</span>
+      <div className="max-w-7xl mx-auto px-4 py-10">
+
+        {/* HEADER */}
+        <div className="mb-6">
+          <h1 className="text-3xl font-bold text-ink capitalize">
+            {slug}
           </h1>
 
-          <p className="text-[#45C4B0] mt-4 text-lg font-semibold">
-            {total} produtos encontrados com histórico de preço
+          <p className="text-sm text-ink-muted mt-1">
+            {total} produtos encontrados
           </p>
-        </header>
-
-        {/* ================= FILTROS ================= */}
-        <div className="mb-14">
-          <CategoryFilters />
         </div>
 
-        {/* ================= GRID ================= */}
+        {/* FILTROS */}
+        <CategoryFilters />
+
+        {/* GRID */}
         {products.length === 0 ? (
-          <div className="text-center mt-20">
-            <p className="text-[#45C4B0] text-lg font-semibold">
-              Nenhum produto encontrado.
-            </p>
-          </div>
+          <p className="text-ink-muted mt-6">
+            Nenhum produto encontrado
+          </p>
         ) : (
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-10">
+          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-6 mt-6">
             {products.map((p) => (
-              <ProductCard key={p.produto_id} product={p} />
+              <ProductCard
+                key={p.produto_id}
+                product={p}
+              />
             ))}
           </div>
         )}
 
-        {/* ================= PAGINAÇÃO ================= */}
+        {/* PAGINAÇÃO */}
         {totalPages > 1 && (
-          <div className="flex justify-center gap-4 mt-20 flex-wrap">
+          <div className="flex justify-center gap-2 mt-12 flex-wrap">
             {Array.from({ length: totalPages }).map((_, i) => {
               const pageNumber = i + 1;
               const isActive = page === pageNumber;
@@ -187,10 +193,10 @@ export default async function CategoryPage(props: {
                       order,
                     },
                   }}
-                  className={`px-5 py-2.5 rounded-xl text-sm font-bold transition ${
+                  className={`px-4 py-2 rounded-lg text-sm font-semibold transition ${
                     isActive
-                      ? "bg-[#F5F138] text-[#000D34] shadow-lg"
-                      : "bg-[#0a154a] text-[#DAFDBA] border border-[#45C4B0] hover:bg-[#45C4B0] hover:text-[#000D34]"
+                      ? "bg-primary text-white"
+                      : "bg-panel text-ink-muted border border-line hover:bg-success hover:text-[#052e16] hover:border-success"
                   }`}
                 >
                   {pageNumber}
@@ -199,6 +205,7 @@ export default async function CategoryPage(props: {
             })}
           </div>
         )}
+
       </div>
     </div>
   );

--- a/promoly-next/src/app/globals.css
+++ b/promoly-next/src/app/globals.css
@@ -7,11 +7,37 @@
 ========================= */
 
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
+  --background: #0a0e1a;
+  --foreground: #f1f5f9;
+}
+
+html {
+  scroll-behavior: smooth;
 }
 
 body {
   background: var(--background);
   color: var(--foreground);
+  -webkit-font-smoothing: antialiased;
+}
+
+::selection {
+  background: rgba(34, 197, 94, 0.3);
+  color: #f1f5f9;
+}
+
+/* subtle scrollbar for dark theme */
+::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+::-webkit-scrollbar-track {
+  background: #0a0e1a;
+}
+::-webkit-scrollbar-thumb {
+  background: #1f2a3d;
+  border-radius: 999px;
+}
+::-webkit-scrollbar-thumb:hover {
+  background: #2b3a52;
 }

--- a/promoly-next/src/app/page.tsx
+++ b/promoly-next/src/app/page.tsx
@@ -150,12 +150,32 @@ export default async function HomePage() {
   };
 
   const categories = [
-    { label: "Eletrônicos", slug: "eletronicos" },
-    { label: "Casa", slug: "casa" },
-    { label: "Pet", slug: "pet" },
-    { label: "Games", slug: "games" },
-    { label: "Fitness", slug: "fitness" },
-    { label: "Automotivo", slug: "automotivo" },
+    { label: "Eletrônicos", slug: "eletronicos", icon: "💻" },
+    { label: "Casa", slug: "casa", icon: "🏠" },
+    { label: "Pet", slug: "pet", icon: "🐾" },
+    { label: "Games", slug: "games", icon: "🎮" },
+    { label: "Fitness", slug: "fitness", icon: "🏋️" },
+    { label: "Automotivo", slug: "automotivo", icon: "🚗" },
+  ];
+
+  /* ===== MÉTRICAS DA HOME ===== */
+  const discounts = ranked
+    .map((p) => ("desconto_pct" in p ? (p.desconto_pct ?? 0) : 0))
+    .filter((d: number) => d > 0);
+
+  const maxDiscount = discounts.length ? Math.max(...discounts) : 0;
+  const avgDiscount = discounts.length
+    ? Math.round(discounts.reduce((a, b) => a + b, 0) / discounts.length)
+    : 0;
+  const belowAvgCount = ranked.filter(
+    (p) => ("desconto_pct" in p ? (p.desconto_pct ?? 0) : 0) >= 15,
+  ).length;
+
+  const stats = [
+    { label: "Ofertas monitoradas", value: ranked.length, accent: "text-ink" },
+    { label: "Maior queda hoje", value: `${maxDiscount}%`, accent: "text-success" },
+    { label: "Queda média", value: `${avgDiscount}%`, accent: "text-primary" },
+    { label: "Oportunidades", value: belowAvgCount, accent: "text-accent" },
   ];
 
   return (
@@ -187,38 +207,83 @@ export default async function HomePage() {
         }}
       />
 
-      <div className="bg-[#000D34] min-h-screen">
-        <div className="max-w-7xl mx-auto px-6 py-16">
-          {/* HERO */}
+      <div className="bg-base min-h-screen">
+        {/* glow de fundo do hero */}
+        <div className="relative overflow-hidden">
+          <div
+            aria-hidden
+            className="pointer-events-none absolute -top-32 left-1/2 -translate-x-1/2 h-[420px] w-[820px] max-w-full rounded-full bg-primary/20 blur-[140px]"
+          />
 
-          <section className="text-center mb-20">
-            <h1 className="text-4xl sm:text-5xl font-extrabold text-[#9AEBA3] mb-6">
-              Compare preços e encontre o{" "}
-              <span className="text-[#F5F138]">menor valor</span> antes de
-              comprar
-            </h1>
+          <div className="relative max-w-7xl mx-auto px-4 sm:px-6 pt-16 pb-12 sm:pt-24">
+            {/* HERO */}
+            <section className="text-center max-w-3xl mx-auto">
+              <span className="inline-flex items-center gap-2 text-xs font-semibold text-ink-muted bg-panel border border-line rounded-full px-4 py-1.5 mb-6">
+                <span className="h-2 w-2 rounded-full bg-success animate-pulse" />
+                Monitorando preços em tempo real
+              </span>
 
-            <p className="text-[#45C4B0] max-w-2xl mx-auto text-lg mb-8">
-              Acompanhe o histórico real de preços e descubra quando um produto
-              está abaixo da média histórica.
-            </p>
+              <h1 className="text-3xl sm:text-5xl font-extrabold text-ink leading-tight mb-5">
+                Compre no <span className="text-success">menor preço</span>,
+                <br className="hidden sm:block" /> sem cair em falsa promoção
+              </h1>
 
-            <Link
-              href="/menor-preco-hoje"
-              className="inline-block bg-[#45C4B0] hover:bg-[#9AEBA3] text-[#000D34] font-semibold px-8 py-3 rounded-xl shadow-medium transition"
-            >
-              🔥 Ver melhores ofertas
-            </Link>
-          </section>
+              <p className="text-ink-muted max-w-xl mx-auto text-base sm:text-lg mb-8">
+                Acompanhe o histórico real de preços e descubra quando um produto
+                está de fato abaixo da média histórica.
+              </p>
 
+              <div className="flex flex-col sm:flex-row gap-3 justify-center">
+                <Link
+                  href="/menor-preco-hoje"
+                  className="inline-flex items-center justify-center bg-success hover:bg-success-glow text-[#052e16] text-base font-bold px-8 py-3 rounded-xl shadow-glow transition"
+                >
+                  🔥 Ver melhores ofertas
+                </Link>
+                <Link
+                  href="/categoria/eletronicos"
+                  className="inline-flex items-center justify-center bg-panel hover:bg-panel-subtle text-ink border border-line font-semibold px-8 py-3 rounded-xl transition"
+                >
+                  Explorar categorias
+                </Link>
+              </div>
+            </section>
+
+            {/* MÉTRICAS */}
+            <section className="grid grid-cols-2 lg:grid-cols-4 gap-3 sm:gap-4 mt-12 sm:mt-16">
+              {stats.map((s) => (
+                <div
+                  key={s.label}
+                  className="bg-panel border border-line rounded-2xl p-4 sm:p-6 text-center"
+                >
+                  <div className={`text-2xl sm:text-3xl font-extrabold ${s.accent}`}>
+                    {s.value}
+                  </div>
+                  <div className="text-xs sm:text-sm text-ink-muted mt-1">
+                    {s.label}
+                  </div>
+                </div>
+              ))}
+            </section>
+          </div>
+        </div>
+
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 pb-16">
           {/* TOP OPORTUNIDADES */}
+          <section className="mb-16 sm:mb-20">
+            <div className="flex items-end justify-between mb-6 sm:mb-8">
+              <h2 className="text-xl sm:text-2xl font-bold text-ink">
+                🔥 Top oportunidades de hoje
+              </h2>
+              <Link
+                href="/menor-preco-hoje"
+                className="text-sm font-medium text-ink-muted hover:text-success transition shrink-0"
+              >
+                Ver todas →
+              </Link>
+            </div>
 
-          <section className="mb-24">
-            <h2 className="text-3xl font-bold text-[#9AEBA3] mb-10">
-              🔥 Top oportunidades de hoje
-            </h2>
-
-            <div className="grid grid-cols-1 sm:grid-cols-1 lg:grid-cols-3 gap-8">
+            <div className="grid grid-cols-2 lg:grid-cols-3 gap-3 sm:gap-6">
               {ranked.slice(0, 3).map((p) => (
                 <ProductCard key={`${p.produto_id}-top`} product={p} />
               ))}
@@ -226,46 +291,46 @@ export default async function HomePage() {
           </section>
 
           {/* CATEGORIAS */}
-
-          <section className="mb-24">
-            <h2 className="text-2xl font-bold text-[#9AEBA3] mb-8">
+          <section className="mb-16 sm:mb-20">
+            <h2 className="text-xl sm:text-2xl font-bold text-ink mb-6">
               Navegue por categorias
             </h2>
 
-            <div className="flex flex-wrap gap-4">
+            <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3">
               {categories.map((cat) => (
                 <Link
                   key={cat.slug}
                   href={`/categoria/${cat.slug}`}
-                  className="px-6 py-2.5 bg-[#DAFDBA] text-[#000D34] rounded-full text-sm font-semibold hover:bg-[#45C4B0] transition shadow-soft"
+                  className="group flex flex-col items-center gap-2 bg-panel border border-line rounded-2xl px-4 py-5 text-center hover:border-primary/50 hover:bg-panel-elevated transition"
                 >
-                  {cat.label}
+                  <span className="text-2xl">{cat.icon}</span>
+                  <span className="text-sm font-medium text-ink-muted group-hover:text-ink transition">
+                    {cat.label}
+                  </span>
                 </Link>
               ))}
             </div>
           </section>
 
           {/* GRID */}
-
           <section>
-            <h2 className="text-3xl font-bold text-[#9AEBA3] mb-10">
+            <h2 className="text-xl sm:text-2xl font-bold text-ink mb-6 sm:mb-8">
               Ofertas em destaque
             </h2>
 
-            <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-4 lg:gap-8">
+            <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 sm:gap-5 lg:grid-cols-4 lg:gap-6">
               {ranked.map((p) => (
                 <ProductCard key={`${p.produto_id}-grid`} product={p} />
               ))}
             </div>
           </section>
 
-          {/* SEO TEXT */}
-
-          <section className="mt-24 text-[#45C4B0] max-w-3xl">
-            <h2 className="text-2xl font-bold mb-4 text-[#9AEBA3]">
+          {/* SEO TEXTO */}
+          <section className="mt-20 max-w-3xl">
+            <h2 className="text-xl sm:text-2xl font-bold text-ink mb-4">
               Como encontrar o menor preço online?
             </h2>
-            <p>
+            <p className="text-ink-muted leading-relaxed">
               O PromoLy é um comparador de preços que analisa o histórico de
               valores e identifica oportunidades reais. Antes de comprar,
               verifique se o preço atual está abaixo da média histórica.

--- a/promoly-next/src/app/produto/[slug]/loading.tsx
+++ b/promoly-next/src/app/produto/[slug]/loading.tsx
@@ -1,37 +1,37 @@
 export default function Loading() {
   return (
-    <div className="g-zinc-950 min-h-screen">
+    <div className="bg-base min-h-screen">
       <div className="max-w-7xl mx-auto px-4 py-10">
         <div className="grid lg:grid-cols-[2fr_1fr] gap-10">
           {/* MAIN */}
           <div className="space-y-8">
             {/* CARD PRINCIPAL */}
-            <div className="bg-white text-white rounded-2xl shadow-sm border border-gray-100 p-8 animate-pulse">
+            <div className="bg-panel rounded-2xl border border-line p-8 animate-pulse">
               <div className="grid md:grid-cols-2 gap-10">
-                <div className="bg-gray-200 rounded-xl h-80"></div>
+                <div className="bg-panel-subtle rounded-xl h-80"></div>
 
                 <div className="space-y-4">
-                  <div className="h-6 bg-gray-200 rounded w-3/4"></div>
-                  <div className="h-4 bg-gray-200 rounded w-1/4"></div>
-                  <div className="h-10 bg-gray-200 rounded w-1/2"></div>
-                  <div className="h-12 bg-gray-200 rounded w-1/3"></div>
+                  <div className="h-6 bg-panel-subtle rounded w-3/4"></div>
+                  <div className="h-4 bg-panel-subtle rounded w-1/4"></div>
+                  <div className="h-10 bg-panel-subtle rounded w-1/2"></div>
+                  <div className="h-12 bg-panel-subtle rounded w-1/3"></div>
                 </div>
               </div>
             </div>
 
             {/* HISTÓRICO */}
-            <div className="bg-white rounded-2xl shadow-sm border border-gray-100 p-8 animate-pulse">
-              <div className="h-6 bg-gray-200 rounded w-1/3 mb-6"></div>
-              <div className="h-64 bg-gray-200 rounded-xl"></div>
+            <div className="bg-panel rounded-2xl border border-line p-8 animate-pulse">
+              <div className="h-6 bg-panel-subtle rounded w-1/3 mb-6"></div>
+              <div className="h-64 bg-panel-subtle rounded-xl"></div>
             </div>
           </div>
 
           {/* ASIDE */}
-          <div className="bg-white rounded-2xl shadow-sm border border-gray-100 p-6 animate-pulse space-y-4">
-            <div className="h-5 bg-gray-200 rounded w-1/2"></div>
-            <div className="h-20 bg-gray-200 rounded-xl"></div>
-            <div className="h-20 bg-gray-200 rounded-xl"></div>
-            <div className="h-20 bg-gray-200 rounded-xl"></div>
+          <div className="bg-panel rounded-2xl border border-line p-6 animate-pulse space-y-4">
+            <div className="h-5 bg-panel-subtle rounded w-1/2"></div>
+            <div className="h-20 bg-panel-subtle rounded-xl"></div>
+            <div className="h-20 bg-panel-subtle rounded-xl"></div>
+            <div className="h-20 bg-panel-subtle rounded-xl"></div>
           </div>
         </div>
       </div>

--- a/promoly-next/src/app/produto/[slug]/page.tsx
+++ b/promoly-next/src/app/produto/[slug]/page.tsx
@@ -7,126 +7,80 @@ const BASE_URL =
   process.env.NEXT_PUBLIC_API_URL || "https://promoly-core.vercel.app";
 
 type Props = {
-  params: Promise<{
-    slug?: string;
-  }>;
+  params: Promise<{ slug: string }>;
 };
 
-/* =========================
-   Função utilitária segura
-========================= */
-function extractIdFromSlug(slug?: string): number | null {
-  if (!slug) return null;
-
-  const idPart = slug.split("-").pop();
-  if (!idPart) return null;
-
-  const id = Number(idPart);
-  return isNaN(id) ? null : id;
-}
-
-/* =========================
-   METADATA
-========================= */
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
-  try {
-    const resolvedParams = await params;
-    const slug = resolvedParams?.slug;
-    const id = extractIdFromSlug(slug);
+  const { slug } = await params;
 
-    if (!slug || !id) {
-      return {};
-    }
-
-    const productData = await fetchProductById(id);
-
-    if (!productData?.produto) {
-      return {};
-    }
-
-    const produto = productData.produto;
-
-    const price =
-      produto.preco != null
-        ? produto.preco.toLocaleString("pt-BR", {
-            style: "currency",
-            currency: "BRL",
-          })
-        : null;
-
-    return {
-      title: produto.titulo,
-      description: price
-        ? `Veja histórico de preço e descubra se vale a pena comprar por ${price}.`
-        : "Veja histórico completo no Promoly.",
-      openGraph: {
-        title: produto.titulo,
-        description: price
-          ? `Atualmente por ${price}. Veja histórico completo no Promoly.`
-          : "Veja histórico completo no Promoly.",
-        url: `${BASE_URL}/produto/${slug}`,
-        images: [
-          {
-            url: produto.imagem_url ?? "/og-image.jpg",
-            width: 1200,
-            height: 630,
-            alt: produto.titulo,
-          },
-        ],
-      },
-      twitter: {
-        card: "summary_large_image",
-        title: produto.titulo,
-        description: price
-          ? `Atualmente por ${price}. Veja histórico completo.`
-          : "Veja histórico completo.",
-        images: [produto.imagem_url ?? "/og-image.jpg"],
-      },
-    };
-  } catch (error) {
-    console.error("Erro em generateMetadata:", error);
+  if (!slug) {
     return {};
   }
-}
 
-/* =========================
-   PAGE
-========================= */
-export default async function ProductPage({ params }: Props) {
-  const resolvedParams = await params;
+  const id = Number(slug.split("-").pop());
 
-  const slug = resolvedParams?.slug;
-  const id = extractIdFromSlug(slug);
-
-  if (!slug || !id) {
-    notFound();
+  if (isNaN(id)) {
+    return {};
   }
 
-  let productData;
-  let prices;
-
-  try {
-    [productData, prices] = await Promise.all([
-      fetchProductById(id),
-      fetchPrices(id),
-    ]);
-  } catch (error) {
-    console.error("Erro ao buscar dados:", error);
-    notFound();
-  }
+  const productData = await fetchProductById(id);
 
   if (!productData?.produto) {
-    notFound();
+    return {};
   }
 
-  const priceHistory = Array.isArray(prices)
-    ? prices
-        .map((p) => ({
-          preco: Number(p.preco),
-          data: new Date(p.created_at).getTime(),
-        }))
-        .sort((a, b) => a.data - b.data)
-    : [];
+  const produto = productData.produto;
+
+  const price = produto.preco?.toLocaleString("pt-BR", {
+    style: "currency",
+    currency: "BRL",
+  });
+
+  return {
+    title: produto.titulo,
+    description: `Veja histórico de preço e descubra se vale a pena comprar por ${price}.`,
+    openGraph: {
+      title: produto.titulo,
+      description: `Atualmente por ${price}. Veja histórico completo no Promoly.`,
+      url: `${BASE_URL}/produto/${slug}`,
+      images: [
+        {
+          url: produto.imagem_url ?? "/og-image.jpg",
+          width: 1200,
+          height: 630,
+          alt: produto.titulo,
+        },
+      ],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: produto.titulo,
+      description: `Atualmente por ${price}. Veja histórico completo.`,
+      images: [produto.imagem_url ?? "/og-image.jpg"],
+    },
+  };
+}
+
+export default async function ProductPage({ params }: Props) {
+  const { slug } = await params;
+
+  const id = Number(slug.split("-").pop());
+
+  if (isNaN(id)) notFound();
+
+  const [productData, prices] = await Promise.all([
+    fetchProductById(id),
+    fetchPrices(id),
+  ]);
+
+  if (!productData?.produto) notFound();
+
+  const priceHistory = prices
+    .map((p) => ({
+      preco: Number(p.preco),
+      data: new Date(p.created_at).getTime(),
+    }))
+    .sort((a, b) => a.data - b.data);
 
   return (
     <ProductView

--- a/promoly-next/src/components/ProductCard.tsx
+++ b/promoly-next/src/components/ProductCard.tsx
@@ -37,31 +37,41 @@ export default function ProductCard({ product, priority = false }: Props) {
   return (
     <article
       className="
-    relative
-    bg-[#0a154a]
-    rounded-2xl
-    border border-[#45C4B0]
-    shadow-lg
-    hover:shadow-2xl
-    transition-all duration-300
-    hover:-translate-y-1
-    hover:border-[#F5F138]
-    p-6
-    flex flex-col
-    group
-  "
+        relative
+        bg-panel
+        rounded-xl2
+        border border-line
+        shadow-elevated
+        hover:border-success/40
+        hover:shadow-glow
+        transition-all duration-300
+        hover:-translate-y-1
+        p-4 sm:p-5
+        flex flex-col
+        group
+      "
     >
-      {/* BADGE DESCONTO */}
-      {isDeal && product.desconto_pct != null && (
-        <span className="absolute top-4 left-4 bg-[#F5F138] text-[#000D34] text-xs font-extrabold px-3 py-1 rounded-full shadow-md z-10">
-          -{product.desconto_pct}% OFF
-        </span>
-      )}
+      {/* BADGES TOPO */}
+      <div className="absolute top-3 left-3 right-3 z-10 flex items-start justify-between pointer-events-none">
+        {isDeal && product.desconto_pct != null ? (
+          <span className="bg-success/15 text-success ring-1 ring-success/30 text-xs font-bold px-2.5 py-1 rounded-full backdrop-blur-sm">
+            −{product.desconto_pct}%
+          </span>
+        ) : (
+          <span />
+        )}
+
+        {showOpportunity && (
+          <span className="bg-accent/15 text-accent ring-1 ring-accent/30 text-xs font-semibold px-2.5 py-1 rounded-full backdrop-blur-sm">
+            🔥 Oportunidade
+          </span>
+        )}
+      </div>
 
       {/* IMAGEM */}
       <Link
         href={productUrl}
-        className="bg-[#000D34] rounded-xl p-4 flex items-center justify-center overflow-hidden"
+        className="bg-white rounded-xl p-4 sm:p-5 flex items-center justify-center overflow-hidden"
       >
         <Image
           src={product.imagem_url ?? "/placeholder.png"}
@@ -70,60 +80,43 @@ export default function ProductCard({ product, priority = false }: Props) {
           height={500}
           priority={priority}
           loading={priority ? "eager" : "lazy"}
-          className="
-        w-full
-        h-auto
-        object-contain
-        aspect-[4/5]
-        sm:aspect-[3/4]
-        scale-110
-        group-hover:scale-[1.18]
-        transition-transform
-        duration-300
-      "
+          className="w-full h-auto object-contain aspect-[4/5] sm:aspect-[3/4] group-hover:scale-105 transition-transform duration-300"
           sizes="
-        (max-width: 640px) 100vw,
-        (max-width: 1024px) 33vw,
-        300px
-      "
+      (max-width: 640px) 50vw,
+      (max-width: 1024px) 33vw,
+      300px
+    "
         />
       </Link>
 
       {/* CONTEÚDO */}
-      <div className="mt-6 flex flex-col gap-3 flex-1">
+      <div className="mt-4 flex flex-col gap-2 flex-1">
         {/* TÍTULO */}
         <Link
           href={productUrl}
-          className="
-        text-base
-        font-semibold
-        text-[#9AEBA3]
-        line-clamp-2
-        hover:text-[#F5F138]
-        transition
-      "
+          className="text-sm sm:text-base font-semibold text-white line-clamp-2 hover:text-success transition min-h-[2.5rem]"
         >
           {product.titulo}
         </Link>
 
         {/* PREÇO */}
-        <div className="flex flex-col">
+        <div className="flex flex-col mt-auto">
           {isDeal ? (
             <>
               {product.preco_anterior != null && (
-                <span className="text-sm text-[#45C4B0] line-through">
+                <span className="text-xs text-ink-faint line-through">
                   R$ {Number(product.preco_anterior).toFixed(2)}
                 </span>
               )}
 
               {product.preco_atual != null && (
-                <span className="text-3xl font-extrabold text-[#F5F138]">
+                <span className="text-xl sm:text-2xl font-extrabold text-success">
                   R$ {Number(product.preco_atual).toFixed(2)}
                 </span>
               )}
             </>
           ) : (
-            <span className="text-3xl font-extrabold text-[#F5F138]">
+            <span className="text-xl sm:text-2xl font-extrabold text-ink">
               {"preco" in product && product.preco != null
                 ? `R$ ${Number(product.preco).toFixed(2)}`
                 : "Preço indisponível"}
@@ -133,27 +126,27 @@ export default function ProductCard({ product, priority = false }: Props) {
 
         {/* ABAIXO DA MÉDIA */}
         {product.isBelowAverage && product.priceDiffPercent != null && (
-          <div className="text-sm text-[#45C4B0] font-bold">
+          <div className="text-xs text-success font-semibold">
             ⬇ {Math.abs(product.priceDiffPercent).toFixed(1)}% abaixo da média
           </div>
         )}
 
         {/* BOTÕES */}
-        <div className="flex gap-3 mt-4">
+        <div className="flex gap-2 mt-3">
           <Link
             href={productUrl}
             className="
-          flex-1
-          bg-[#DAFDBA]
-          hover:bg-[#45C4B0]
-          text-[#000D34]
-          text-sm
-          font-semibold
-          py-2.5
-          rounded-xl
-          transition
-          text-center
-        "
+              flex-1
+              bg-panel-subtle
+              hover:bg-line
+              text-ink-muted hover:text-ink
+              text-sm
+              font-medium
+              py-2.5
+              rounded-xl
+              transition
+              text-center
+            "
           >
             Detalhes
           </Link>
@@ -164,29 +157,22 @@ export default function ProductCard({ product, priority = false }: Props) {
               target="_blank"
               rel="noopener noreferrer sponsored"
               className="
-            flex-1
-            bg-[#F5F138]
-            hover:brightness-95
-            text-[#000D34]
-            text-sm
-            font-bold
-            py-2.5
-            rounded-xl
-            transition
-            text-center
-          "
+                flex-1
+                bg-primary
+                hover:bg-primary-hover
+                text-white
+                text-sm
+                font-semibold
+                py-2.5
+                rounded-xl
+                transition
+                text-center
+              "
             >
               Comprar
             </a>
           )}
         </div>
-
-        {/* BADGE OPORTUNIDADE */}
-        {showOpportunity && (
-          <span className="absolute bottom-0 right-4 bg-[#45C4B0] text-[#000D34] text-xs font-extrabold px-3 py-1 rounded-full shadow-md">
-            🔥 Oportunidade
-          </span>
-        )}
       </div>
     </article>
   );

--- a/promoly-next/src/components/category/CategoryFilters.tsx
+++ b/promoly-next/src/components/category/CategoryFilters.tsx
@@ -24,8 +24,10 @@ export default function CategoryFilters() {
 
     router.push(`?${params.toString()}`);
   }
+
   return (
-    <div className="flex flex-col sm:flex-row gap-4 mb-12">
+    <div className="flex flex-col sm:flex-row gap-4 mb-10">
+
       {/* ================= BUSCA ================= */}
       <input
         type="text"
@@ -38,44 +40,45 @@ export default function CategoryFilters() {
           }
         }}
         className="
-        w-full sm:w-72
-        px-4 py-3
-        bg-[#0a154a]
-        border border-[#45C4B0]
-        rounded-xl
-        text-[#9AEBA3]
-        placeholder:text-[#45C4B0]
-        font-semibold
-        focus:outline-none
-        focus:ring-2
-        focus:ring-[#F5F138]
-        focus:border-[#F5F138]
-        transition
-      "
+          w-full sm:w-64
+          px-4 py-3
+          bg-panel
+          border border-line
+          rounded-xl
+          text-ink
+          placeholder:text-ink-faint
+          focus:outline-none
+          focus:ring-2
+          focus:ring-primary
+          focus:border-primary
+          transition
+        "
       />
 
       {/* ================= FILTRO ================= */}
       <select
         value={currentOrder}
-        onChange={(e) => updateParams({ order: e.target.value })}
+        onChange={(e) =>
+          updateParams({ order: e.target.value })
+        }
         className="
-        px-4 py-3
-        bg-[#0a154a]
-        border border-[#45C4B0]
-        rounded-xl
-        text-[#9AEBA3]
-        font-semibold
-        focus:outline-none
-        focus:ring-2
-        focus:ring-[#F5F138]
-        focus:border-[#F5F138]
-        transition
-      "
+          px-4 py-3
+          bg-panel
+          border border-line
+          rounded-xl
+          text-ink
+          focus:outline-none
+          focus:ring-2
+          focus:ring-primary
+          focus:border-primary
+          transition
+        "
       >
         <option value="desconto">Maior desconto</option>
         <option value="preco">Menor preço</option>
         <option value="recentes">Mais recentes</option>
       </select>
+
     </div>
   );
 }

--- a/promoly-next/src/components/layout/Footer.tsx
+++ b/promoly-next/src/components/layout/Footer.tsx
@@ -1,12 +1,14 @@
 import Link from "next/link";
-
 export default function Footer() {
   return (
-    <footer className="bg-gray-900 text-gray-300 mt-24">
+    <footer className="bg-panel border-t border-line text-ink-muted mt-24">
       <div className="max-w-7xl mx-auto px-6 py-12 grid md:grid-cols-3 gap-10">
         {/* SOBRE */}
         <div>
-          <h3 className="text-white text-lg font-semibold mb-4">PromoLy</h3>
+          <h3 className="text-lg font-extrabold mb-4">
+            <span className="text-primary">Promo</span>
+            <span className="text-success">ly</span>
+          </h3>
           <p className="text-sm leading-relaxed">
             Compare preços, acompanhe histórico real e descubra quando um
             produto está realmente abaixo da média.
@@ -15,17 +17,17 @@ export default function Footer() {
 
         {/* LINKS ÚTEIS */}
         <div>
-          <h3 className="text-white text-lg font-semibold mb-4">Links úteis</h3>
+          <h3 className="text-ink text-lg font-semibold mb-4">Links úteis</h3>
           <ul className="space-y-2 text-sm">
             <li>
-              <a href="/sitemap.xml" className="hover:text-white transition">
+              <a href="/sitemap.xml" className="hover:text-ink transition">
                 Sitemap
               </a>
             </li>
             <li>
               <Link
                 href="/categoria/eletronicos"
-                className="hover:text-white transition"
+                className="hover:text-ink transition"
               >
                 Eletrônicos
               </Link>
@@ -33,7 +35,7 @@ export default function Footer() {
             <li>
               <Link
                 href="/categoria/games"
-                className="hover:text-white transition"
+                className="hover:text-ink transition"
               >
                 Games
               </Link>
@@ -41,7 +43,7 @@ export default function Footer() {
             <li>
               <Link
                 href="/categoria/casa"
-                className="hover:text-white transition"
+                className="hover:text-ink transition"
               >
                 Casa
               </Link>
@@ -51,15 +53,13 @@ export default function Footer() {
 
         {/* REDES SOCIAIS */}
         <div>
-          <h3 className="text-white text-lg font-semibold mb-4">
-            Redes sociais
-          </h3>
+          <h3 className="text-ink text-lg font-semibold mb-4">Redes sociais</h3>
           <div className="flex flex-col gap-2 text-sm">
             <a
               href="https://instagram.com/Promoly__"
               target="_blank"
               rel="noopener noreferrer"
-              className="hover:text-white transition"
+              className="hover:text-ink transition"
             >
               Instagram
             </a>
@@ -68,7 +68,7 @@ export default function Footer() {
               href="https://twitter.com/Promoly_"
               target="_blank"
               rel="noopener noreferrer"
-              className="hover:text-white transition"
+              className="hover:text-ink transition"
             >
               Twitter
             </a>
@@ -78,7 +78,7 @@ export default function Footer() {
               https://www.facebook.com/PromolyCore"
               target="_blank"
               rel="noopener noreferrer"
-              className="hover:text-white transition"
+              className="hover:text-ink transition"
             >
               Facebook
             </a>
@@ -86,7 +86,7 @@ export default function Footer() {
         </div>
       </div>
 
-      <div className="border-t border-gray-700 py-6 text-center text-xs text-gray-400">
+      <div className="border-t border-line py-6 text-center text-xs text-ink-faint">
         © {new Date().getFullYear()} PromoLy. Todos os direitos reservados.
       </div>
     </footer>

--- a/promoly-next/src/components/layout/Header.tsx
+++ b/promoly-next/src/components/layout/Header.tsx
@@ -17,17 +17,15 @@ export default function Header() {
   );
 
   return (
-    <header className="bg-[#000D34] border-b border-[#0f1a4d] sticky top-0 z-50 shadow-soft">
+    <header className="bg-base/80 backdrop-blur-xl border-b border-line sticky top-0 z-50">
       <div className="max-w-7xl mx-auto px-4 h-16 flex items-center justify-between">
+        {/* LOGO */}
         <Link
           href="/"
-          className="flex items-center gap-2 text-2xl font-extrabold tracking-tight"
+          className="flex items-center text-2xl font-extrabold tracking-tight"
         >
-          <span className="text-[#9AEBA3]">Promo</span>
-          <span>
-            <span className="text-[#F5F138]">l</span>
-            <span className="text-[#9AEBA3]">y</span>
-          </span>
+          <span className="text-primary">Promo</span>
+          <span className="text-success">ly</span>
         </Link>
 
         {/* DESKTOP MENU */}
@@ -36,7 +34,7 @@ export default function Header() {
             <Link
               key={cat.slug}
               href={`/categoria/${cat.slug}`}
-              className="text-[#9AEBA3] hover:opacity-80 transition font-semibold"
+              className="text-ink-muted hover:text-ink transition font-medium"
             >
               {cat.label}
             </Link>
@@ -44,7 +42,7 @@ export default function Header() {
 
           {/* DROPDOWN */}
           <div className="relative group">
-            <button className="text-[#9AEBA3] hover:opacity-80 transition font-semibold">
+            <button className="text-ink-muted hover:text-ink transition font-medium">
               Mais ▾
             </button>
 
@@ -54,22 +52,22 @@ export default function Header() {
               className="
                 absolute left-0 top-full
                 w-52
-                bg-[#000D34]
-                border border-[#0f1a4d]
+                bg-panel-elevated
+                border border-line
                 rounded-xl
-                shadow-medium
+                shadow-elevated
                 p-4
                 hidden
                 group-hover:flex
                 flex-col
-                gap-2
+                gap-1
               "
             >
               {otherCategories.map((cat) => (
                 <Link
                   key={cat.slug}
                   href={`/categoria/${cat.slug}`}
-                  className="text-[#9AEBA3] hover:opacity-80 text-sm transition font-medium"
+                  className="text-ink-muted hover:text-ink hover:bg-panel-subtle rounded-lg px-3 py-2 text-sm transition font-medium"
                 >
                   {cat.label}
                 </Link>
@@ -80,37 +78,38 @@ export default function Header() {
 
         {/* MOBILE BUTTON */}
         <button
-          className="md:hidden text-[#9AEBA3] text-2xl"
+          className="md:hidden text-ink text-2xl"
+          aria-label="Abrir menu"
           onClick={() => setMobileOpen(!mobileOpen)}
         >
-          ☰
+          {mobileOpen ? "✕" : "☰"}
         </button>
       </div>
 
       {/* MOBILE MENU */}
       {mobileOpen && (
-        <div className="md:hidden bg-[#000D34] border-t border-[#0f1a4d] shadow-soft">
-          <div className="flex flex-col px-4 py-4 gap-4 text-sm">
+        <div className="md:hidden bg-panel border-t border-line">
+          <div className="flex flex-col px-4 py-4 gap-1 text-sm">
             {mainCategories.map((cat) => (
               <Link
                 key={cat.slug}
                 href={`/categoria/${cat.slug}`}
                 onClick={() => setMobileOpen(false)}
-                className="text-[#9AEBA3] font-medium hover:opacity-80 transition"
+                className="text-ink font-medium hover:bg-panel-subtle rounded-lg px-3 py-2.5 transition"
               >
                 {cat.label}
               </Link>
             ))}
 
             <button
-              className="text-left text-[#9AEBA3] font-semibold"
+              className="text-left text-ink-muted font-semibold px-3 py-2.5"
               onClick={() => setMoreOpen(!moreOpen)}
             >
-              Mais categorias
+              Mais categorias {moreOpen ? "▴" : "▾"}
             </button>
 
             {moreOpen && (
-              <div className="flex flex-col gap-2 pl-4 border-l border-[#1b2a66]">
+              <div className="flex flex-col gap-1 pl-4 border-l border-line ml-3">
                 {otherCategories.map((cat) => (
                   <Link
                     key={cat.slug}
@@ -119,7 +118,7 @@ export default function Header() {
                       setMobileOpen(false);
                       setMoreOpen(false);
                     }}
-                    className="text-[#9AEBA3] hover:opacity-80 transition"
+                    className="text-ink-muted hover:text-ink rounded-lg px-3 py-2 transition"
                   >
                     {cat.label}
                   </Link>

--- a/promoly-next/src/features/category_low_prices/CategoryLowPricesView.tsx
+++ b/promoly-next/src/features/category_low_prices/CategoryLowPricesView.tsx
@@ -28,30 +28,25 @@ export default function CategoryLowestPriceView({
   const today = new Date().toLocaleDateString("pt-BR");
 
   return (
-    <div className="bg-[#000D34] min-h-screen">
-      <div className="max-w-7xl mx-auto px-6 py-16">
-        {/* ================= HEADER ================= */}
-        <header className="mb-20 text-center">
-          <h1 className="text-3xl sm:text-4xl md:text-5xl font-extrabold text-[#9AEBA3] leading-tight mb-4">
-            🔥 Menor preço em{" "}
-            <span className="text-[#F5F138]">{categoriaNome}</span> hoje
+    <div className="bg-base min-h-screen">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 py-14">
+        <header className="mb-12 sm:mb-16">
+          <h1 className="text-3xl sm:text-4xl font-bold mb-4 text-ink">
+            🔥 Menor preço em {categoriaNome} hoje
           </h1>
-
-          <p className="text-[#45C4B0] text-lg font-semibold">
+          <p className="text-ink-muted">
             Produtos abaixo da média histórica. Atualizado em {today}
           </p>
         </header>
 
-        {/* ================= HERO ================= */}
+        {/* HERO vindo da page (igual à principal) */}
         <CategoryHeroHighlight product={heroProduct} />
 
-        {/* ================= GRID ================= */}
-        <div className="mt-20">
-          <CategoryLowestGrid products={enriched} />
-        </div>
+        {/* GRID usando enriched já tratado */}
+        <CategoryLowestGrid products={enriched} />
       </div>
 
-      {/* ================= SCHEMAS ================= */}
+      {/* SCHEMAS */}
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{

--- a/promoly-next/src/features/category_low_prices/components/CategoryLowestGrid/index.tsx
+++ b/promoly-next/src/features/category_low_prices/components/CategoryLowestGrid/index.tsx
@@ -8,7 +8,7 @@ type Props = {
 export default function CategoryLowestGrid({ products }: Props) {
   return (
     <section>
-      <h2 className="text-2xl font-bold mb-10">Todos abaixo da média</h2>
+      <h2 className="text-2xl font-bold mb-10 text-ink">Todos abaixo da média</h2>
 
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-8">
         {products.map((p) => (

--- a/promoly-next/src/features/low_prices/LowPricesView.tsx
+++ b/promoly-next/src/features/low_prices/LowPricesView.tsx
@@ -1,8 +1,10 @@
 import Highlight from "./components/HeroHighlight";
 import CategorySection from "./components/CategorySections";
 import FAQSection from "./components/FAQSection";
+
 import { buildLowestPriceSchemas } from "./utils/lowestPriceSchema";
 import type { EnrichedProduct } from "@/types";
+
 
 type Props = {
   enriched: EnrichedProduct[];
@@ -31,52 +33,48 @@ export default function LowPriceView({
   );
 
   return (
-    <div className="bg-[#000D34] min-h-screen">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 py-10 sm:py-16">
+    <div className="bg-base min-h-screen">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 py-8 sm:py-14">
         {/* ================= HEADER ================= */}
-        <header className="mb-20 text-center">
-          <h1 className="text-3xl sm:text-4xl md:text-5xl font-extrabold text-[#9AEBA3] leading-tight mb-4">
-            🔥 Radar de Oportunidades –{" "}
-            <span className="text-[#F5F138]">
-              Produtos abaixo da média histórica
-            </span>
+        <header className="mb-12 sm:mb-16">
+          <h1 className="text-2xl sm:text-3xl md:text-5xl font-bold leading-tight mb-3 text-ink">
+            🔥 Radar de Oportunidades – Produtos abaixo da média histórica
           </h1>
-
-          <p className="text-[#45C4B0] text-lg">Atualizado em {today}</p>
+          <p className="text-ink-muted text-lg">Atualizado em {today}</p>
         </header>
 
         {/* ================= HERO GLOBAL ================= */}
-        <section className="mb-24">
-          <div className="bg-[#0a154a] rounded-2xl border border-[#45C4B0] p-6 sm:p-10 shadow-lg">
-            <Highlight product={heroProduct} />
-          </div>
+        <section className="mb-16 sm:mb-20">
+          <Highlight product={heroProduct} />
         </section>
 
         {/* ================= EXPLICAÇÃO SEO ================= */}
-        <section className="max-w-3xl mx-auto mb-28">
-          <div className="bg-[#0a154a] rounded-2xl border border-[#45C4B0] p-8 sm:p-12 text-center shadow-lg">
+        <section className="max-w-3xl mx-auto mb-16 sm:mb-24">
+          <div className="bg-panel rounded-2xl shadow-elevated border border-line p-8 sm:p-10 text-center">
             <div className="flex items-center justify-center gap-3 mb-6">
-              <span className="text-2xl bg-[#45C4B0] text-[#000D34] rounded-lg px-3 py-1 font-bold">
-                💡
-              </span>
-
-              <h2 className="text-2xl md:text-3xl font-bold text-[#9AEBA3]">
+              <span className="text-2xl bg-primary/10 rounded-lg p-2">💡</span>
+              <h2 className="text-2xl md:text-3xl font-bold text-ink">
                 Como identificamos o menor preço?
               </h2>
             </div>
 
-            <p className="text-[#45C4B0] text-lg mb-4 font-bold">
+            <p className="text-ink-muted text-lg mb-4">
               Monitoramos automaticamente o histórico de{" "}
-              <span className="text-[#F5F138]">milhares de produtos</span>. Só
-              aparecem aqui quando estão{" "}
-              <span className="text-[#F5F138]">abaixo da média histórica</span>.
+              <span className="font-semibold text-primary">
+                milhares de produtos
+              </span>
+              . Só aparecem aqui quando estão{" "}
+              <span className="font-semibold text-success">
+                abaixo da média histórica
+              </span>
+              .
             </p>
 
-            <p className="text-[#45C4B0] mb-2 font-bold">
+            <p className="text-ink-muted mb-2">
               Aqui você vê quedas reais, não promoções artificiais.
             </p>
 
-            <p className="text-[#45C4B0] text-sm opacity-80 font-bold">
+            <p className="text-ink-faint text-sm">
               Atualização várias vezes ao dia para garantir oportunidades reais.
             </p>
           </div>

--- a/promoly-next/src/features/low_prices/components/CategorySections/CategoryProductActions.tsx
+++ b/promoly-next/src/features/low_prices/components/CategorySections/CategoryProductActions.tsx
@@ -6,26 +6,24 @@ type Props = {
 
 export default function CategoryProductActions({ product }: Props) {
   return (
-    <div className="flex flex-col sm:flex-row gap-4 mt-10">
-      {/* DETALHES */}
+    <div className="flex gap-4 mt-8">
       <a
         href={`/produto/${product.slug}-${product.produto_id}`}
         className="
           flex-1
-          bg-[#DAFDBA]
-          hover:bg-[#45C4B0]
-          text-[#000D34]
-          font-semibold
+          bg-panel-subtle
+          hover:bg-line
+          text-ink-muted hover:text-ink
+          border border-line
           py-3
           rounded-xl
           text-center
           transition
         "
       >
-        Ver detalhes
+        Detalhes
       </a>
 
-      {/* COMPRAR */}
       {product.url_afiliada && (
         <a
           href={product.url_afiliada}
@@ -33,17 +31,16 @@ export default function CategoryProductActions({ product }: Props) {
           rel="noopener noreferrer sponsored"
           className="
             flex-1
-            bg-[#F5F138]
-            hover:brightness-95
-            text-[#000D34]
-            font-bold
+            bg-primary
+            hover:bg-primary-hover
+            text-white
             py-3
             rounded-xl
             text-center
             transition
           "
         >
-          Comprar agora
+          Comprar
         </a>
       )}
     </div>

--- a/promoly-next/src/features/low_prices/components/CategorySections/CategoryProductMetrics.tsx
+++ b/promoly-next/src/features/low_prices/components/CategorySections/CategoryProductMetrics.tsx
@@ -5,80 +5,74 @@ type Props = {
 };
 
 export default function CategoryProductMetrics({ product }: Props) {
-  const formatCurrency = (value: number) =>
-    value.toLocaleString("pt-BR", {
-      style: "currency",
-      currency: "BRL",
-    });
-
   return (
     <>
-      {/* TÍTULO */}
-      <h3 className="text-xl font-semibold text-[#9AEBA3] mb-4 leading-snug">
-        {product.titulo}
-      </h3>
+      <h3 className="text-lg font-semibold mb-3 text-ink">{product.titulo}</h3>
 
-      {/* PREÇO ATUAL */}
-      <p className="text-4xl font-extrabold text-[#F5F138] mb-8">
-        {formatCurrency(product.currentPrice)}
+      <p className="text-3xl font-extrabold text-success mb-6">
+        {product.currentPrice.toLocaleString("pt-BR", {
+          style: "currency",
+          currency: "BRL",
+        })}
       </p>
 
-      {/* MÉTRICAS */}
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-6 mb-8">
+      <div className="grid grid-cols-2 gap-6 mb-6">
         {/* MÉDIA HISTÓRICA */}
-        <div className="bg-[#0a154a] border border-[#45C4B0] rounded-xl p-5">
-          <p className="text-xs text-[#45C4B0] uppercase mb-2 tracking-wide">
-            Média histórica
+        <div>
+          <p className="text-xs text-ink-faint uppercase mb-1">Média histórica</p>
+          <p className="font-semibold text-lg text-ink">
+            {product.avgPrice.toLocaleString("pt-BR", {
+              style: "currency",
+              currency: "BRL",
+            })}
           </p>
-
-          <p className="font-semibold text-lg text-[#9AEBA3]">
-            {formatCurrency(product.avgPrice)}
-          </p>
-
-          <p
-            className={`font-bold text-base ${
-              product.priceDiffPercent > 0 ? "text-red-400" : "text-[#F5F138]"
-            }`}
-          >
-            {product.priceDiffPercent > 0 ? "+" : ""}
+          <p className="text-success font-bold">
             {product.priceDiffPercent.toFixed(1)}% (
-            {formatCurrency(product.currentPrice - product.avgPrice)})
+            {(product.currentPrice - product.avgPrice).toLocaleString("pt-BR", {
+              style: "currency",
+              currency: "BRL",
+            })}
+            )
           </p>
         </div>
 
         {/* ÚLTIMO PREÇO */}
         {product.lastPrice !== null && (
-          <div className="bg-[#0a154a] border border-[#45C4B0] rounded-xl p-5">
-            <p className="text-xs text-[#45C4B0] uppercase mb-2 tracking-wide">
-              Último preço
+          <div>
+            <p className="text-xs text-ink-faint uppercase mb-1">Último preço</p>
+            <p className="font-semibold text-lg text-ink">
+              {product.lastPrice.toLocaleString("pt-BR", {
+                style: "currency",
+                currency: "BRL",
+              })}
             </p>
-
-            <p className="font-semibold text-lg text-[#9AEBA3]">
-              {formatCurrency(product.lastPrice)}
-            </p>
-
             <p
-              className={`font-bold text-base ${
-                product.variationVsLast > 0 ? "text-red-400" : "text-[#F5F138]"
+              className={`font-bold ${
+                product.variationVsLast > 0 ? "text-danger" : "text-success"
               }`}
             >
               {product.variationVsLast > 0 ? "+" : ""}
               {product.variationVsLast.toFixed(1)}% (
-              {formatCurrency(product.currentPrice - product.lastPrice)})
+              {(product.currentPrice - product.lastPrice).toLocaleString(
+                "pt-BR",
+                {
+                  style: "currency",
+                  currency: "BRL",
+                },
+              )}
+              )
             </p>
           </div>
         )}
       </div>
 
       {/* HISTÓRICO TEXTO */}
-      <h4 className="text-lg font-bold text-[#9AEBA3] mb-3">
-        Histórico de preço
-      </h4>
+      <h4 className="text-base font-bold mb-2 text-ink">Histórico de preço</h4>
 
       {product.variationVsLast !== null && (
         <p
-          className={`text-base font-semibold ${
-            product.variationVsLast > 0 ? "text-red-400" : "text-[#F5F138]"
+          className={`text-sm mb-6 font-medium ${
+            product.variationVsLast > 0 ? "text-danger" : "text-success"
           }`}
         >
           {product.variationVsLast > 0 ? "⬆" : "⬇"}{" "}

--- a/promoly-next/src/features/low_prices/components/CategorySections/CategoryTopProduct.tsx
+++ b/promoly-next/src/features/low_prices/components/CategorySections/CategoryTopProduct.tsx
@@ -10,40 +10,23 @@ type Props = {
 
 export default function CategoryTopProduct({ product }: Props) {
   return (
-    <div className="bg-[#0a154a] border border-[#45C4B0] rounded-2xl p-8 sm:p-10 shadow-lg mb-16">
-      {/* BLOCO SUPERIOR */}
-      <div className="grid md:grid-cols-2 gap-12 items-start mb-14">
-        {/* IMAGEM */}
-        <div className="flex justify-center">
+    <div className="bg-panel rounded-2xl p-4 sm:p-6 shadow-elevated border border-line mb-10">
+      <div className="grid md:grid-cols-2 gap-8 md:gap-10">
+        <div className="bg-white rounded-xl p-6 flex items-center justify-center">
           <Image
             src={product.imagem_url ?? "/placeholder.png"}
             alt={product.titulo}
             width={500}
             height={500}
-            className="
-      w-full
-      max-w-[416px]      /* 30% maior no mobile */
-      sm:max-w-[420px]   /* desktop mantém */
-      h-auto
-      rounded-xl
-      object-contain
-      transition-transform
-      duration-300
-      hover:scale-105
-    "
+            className="w-full rounded-xl object-contain"
           />
         </div>
 
-        {/* MÉTRICAS + AÇÕES */}
         <div>
           <CategoryProductMetrics product={product} />
+          <CategoryProductChart product={product} />
           <CategoryProductActions product={product} />
         </div>
-      </div>
-
-      {/* GRÁFICO FULL WIDTH */}
-      <div className="mt-6">
-        <CategoryProductChart product={product} />
       </div>
     </div>
   );

--- a/promoly-next/src/features/low_prices/components/FAQSection/FAQCard.tsx
+++ b/promoly-next/src/features/low_prices/components/FAQSection/FAQCard.tsx
@@ -7,14 +7,14 @@ type Props = {
 
 export default function FAQCard({ icon, iconBg, title, content }: Props) {
   return (
-    <div className="bg-white rounded-2xl p-8 md:p-10 shadow-soft border border-gray-100 hover:shadow-medium hover:-translate-y-1 transition-all duration-300 group">
+    <div className="bg-panel rounded-2xl p-6 md:p-8 shadow-elevated border border-line hover:border-primary/40 hover:-translate-y-1 transition-all duration-300 group">
       <div className="flex items-start gap-4 mb-5">
         <div className={`${iconBg} rounded-xl p-3 flex-shrink-0 group-hover:scale-110 transition-transform`}>
           <span className="text-2xl">{icon}</span>
         </div>
-        <h3 className="text-lg md:text-xl font-bold text-gray-900 leading-tight">{title}</h3>
+        <h3 className="text-lg md:text-xl font-bold text-ink leading-tight">{title}</h3>
       </div>
-      <p className="text-gray-600 leading-relaxed text-base">{content}</p>
+      <p className="text-ink-muted leading-relaxed text-base [&_strong]:text-ink">{content}</p>
     </div>
   );
 }

--- a/promoly-next/src/features/low_prices/components/FAQSection/FAQHeader.tsx
+++ b/promoly-next/src/features/low_prices/components/FAQSection/FAQHeader.tsx
@@ -4,10 +4,10 @@ export default function FAQHeader() {
       <div className="bg-primary/5 rounded-full p-4 mb-6">
         <span className="text-4xl">❓</span>
       </div>
-      <h2 className="text-4xl md:text-5xl font-bold mb-4 max-w-2xl">
+      <h2 className="text-3xl md:text-5xl font-bold mb-4 max-w-2xl text-ink">
         Dúvidas sobre o Radar de Oportunidades?
       </h2>
-      <p className="text-gray-600 text-lg max-w-2xl leading-relaxed">
+      <p className="text-ink-muted text-lg max-w-2xl leading-relaxed">
         Aqui você encontra respostas sobre como funcionam nossas análises de preço e como identificamos as melhores oportunidades para você economizar.
       </p>
     </div>

--- a/promoly-next/src/features/low_prices/components/HeroHighlight/HeroActions.tsx
+++ b/promoly-next/src/features/low_prices/components/HeroHighlight/HeroActions.tsx
@@ -6,26 +6,24 @@ type Props = {
 
 export default function HeroActions({ product }: Props) {
   return (
-    <div className="flex flex-col sm:flex-row gap-4 mt-10">
-      {/* DETALHES */}
+    <div className="flex gap-4 mt-8 justify-start">
       <a
         href={`/produto/${product.slug}-${product.produto_id}`}
         className="
           flex-1
-          bg-[#DAFDBA]
-          hover:bg-[#45C4B0]
-          text-[#000D34]
-          font-semibold
+          bg-panel-subtle
+          hover:bg-line
+          text-ink-muted hover:text-ink
+          border border-line
           py-3
           rounded-xl
           text-center
           transition
         "
       >
-        Ver detalhes
+        Detalhes
       </a>
 
-      {/* COMPRAR */}
       {product.url_afiliada && (
         <a
           href={product.url_afiliada}
@@ -33,17 +31,16 @@ export default function HeroActions({ product }: Props) {
           rel="noopener noreferrer sponsored"
           className="
             flex-1
-            bg-[#F5F138]
-            hover:brightness-95
-            text-[#000D34]
-            font-bold
+            bg-primary
+            hover:bg-primary-hover
+            text-white
             py-3
             rounded-xl
             text-center
             transition
           "
         >
-          Comprar agora
+          Comprar
         </a>
       )}
     </div>

--- a/promoly-next/src/features/low_prices/components/HeroHighlight/HeroImage.tsx
+++ b/promoly-next/src/features/low_prices/components/HeroHighlight/HeroImage.tsx
@@ -7,44 +7,20 @@ type Props = {
 
 export default function HeroImage({ product }: Props) {
   return (
-    <div className="w-full flex justify-center">
-      <div
-        className="
-  bg-[#0a154a]
-  border border-[#45C4B0]
-  rounded-2xl
-  p-6 sm:p-8
-  shadow-lg
-  flex
-  justify-center
-  items-center
-"
-      >
-        <Image
-          src={product.imagem_url ?? "/placeholder.png"}
-          alt={product.titulo}
-          width={600}
-          height={600}
-          priority
-          className="
-      w-full
-      max-w-[390px]      /* 30% maior no mobile */
-      sm:max-w-[380px]
-      md:max-w-[480px]
-      h-auto
-      object-contain
-      rounded-xl
-      transition-transform
-      duration-300
-      hover:scale-105
-    "
-          sizes="
-      (max-width: 640px) 390px,
-      (max-width: 1024px) 380px,
-      480px
-    "
-        />
-      </div>
+    <div className="w-full flex justify-center bg-white rounded-2xl p-6">
+      <Image
+        src={product.imagem_url ?? "/placeholder.png"}
+        alt={product.titulo}
+        width={600}
+        height={600}
+        priority
+        className="w-full max-w-[260px] sm:max-w-[340px] md:max-w-[420px] h-auto object-contain rounded-xl"
+        sizes="
+          (max-width: 640px) 260px,
+          (max-width: 1024px) 340px,
+          420px
+        "
+      />
     </div>
   );
 }

--- a/promoly-next/src/features/low_prices/components/HeroHighlight/HeroMetrics.tsx
+++ b/promoly-next/src/features/low_prices/components/HeroHighlight/HeroMetrics.tsx
@@ -7,6 +7,7 @@ type Props = {
 export default function HeroMetrics({ product }: Props) {
   if (!product) return null;
 
+  // 🔹 Mapear campos do backend (português → padrão interno)
   const currentPrice =
     "preco_atual" in product && typeof product.preco_atual === "number"
       ? product.preco_atual
@@ -17,6 +18,7 @@ export default function HeroMetrics({ product }: Props) {
       ? product.preco_anterior
       : (product.previousPrice ?? null);
 
+  // 🔹 Média histórica (fallback)
   const avgPrice =
     typeof product.avgPrice === "number"
       ? product.avgPrice
@@ -25,9 +27,11 @@ export default function HeroMetrics({ product }: Props) {
   const lastPrice =
     typeof product.lastPrice === "number" ? product.lastPrice : null;
 
+  // 🔹 Diferença vs média
   const priceDiffPercent =
     avgPrice > 0 ? ((currentPrice - avgPrice) / avgPrice) * 100 : 0;
 
+  // 🔹 Variação vs último preço
   const variationVsLast =
     lastPrice && lastPrice > 0
       ? ((currentPrice - lastPrice) / lastPrice) * 100
@@ -41,30 +45,29 @@ export default function HeroMetrics({ product }: Props) {
 
   return (
     <>
-      {/* TÍTULO */}
-      <h3 className="text-lg sm:text-xl font-semibold text-[#9AEBA3] mb-3 leading-snug">
+      <h3 className="text-base sm:text-lg font-semibold mb-2 leading-snug text-ink">
         {product.titulo}
       </h3>
 
       {/* PREÇO ATUAL */}
-      <p className="text-3xl sm:text-5xl font-extrabold text-[#F5F138] mb-8">
+      <p className="text-2xl sm:text-4xl font-extrabold text-success mb-4 sm:mb-8">
         {formatCurrency(currentPrice)}
       </p>
 
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-6 mb-10">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 sm:gap-8 mb-6 sm:mb-10">
         {/* MÉDIA HISTÓRICA */}
-        <div className="bg-[#0a154a] border border-[#45C4B0] rounded-xl p-5">
-          <p className="text-xs text-[#45C4B0] uppercase mb-2 tracking-wide">
+        <div className="bg-panel-subtle border border-line rounded-lg p-3 sm:p-4">
+          <p className="text-[10px] sm:text-xs text-ink-faint uppercase mb-1">
             Média histórica
           </p>
 
-          <p className="font-semibold text-lg text-[#9AEBA3]">
+          <p className="font-semibold text-base sm:text-lg text-ink">
             {formatCurrency(avgPrice)}
           </p>
 
           <p
-            className={`font-bold text-base ${
-              priceDiffPercent > 0 ? "text-red-400" : "text-[#F5F138]"
+            className={`font-bold text-sm sm:text-base ${
+              priceDiffPercent > 0 ? "text-danger" : "text-success"
             }`}
           >
             {priceDiffPercent > 0 ? "+" : ""}
@@ -75,18 +78,18 @@ export default function HeroMetrics({ product }: Props) {
 
         {/* ÚLTIMO PREÇO */}
         {lastPrice && (
-          <div className="bg-[#0a154a] border border-[#45C4B0] rounded-xl p-5">
-            <p className="text-xs text-[#45C4B0] uppercase mb-2 tracking-wide">
+          <div className="bg-panel-subtle border border-line rounded-lg p-3 sm:p-4">
+            <p className="text-[10px] sm:text-xs text-ink-faint uppercase mb-1">
               Último preço
             </p>
 
-            <p className="font-semibold text-lg text-[#9AEBA3]">
+            <p className="font-semibold text-base sm:text-lg text-ink">
               {formatCurrency(lastPrice)}
             </p>
 
             <p
-              className={`font-bold text-base ${
-                variationVsLast > 0 ? "text-red-400" : "text-[#F5F138]"
+              className={`font-bold text-sm sm:text-base ${
+                variationVsLast > 0 ? "text-danger" : "text-success"
               }`}
             >
               {variationVsLast > 0 ? "+" : ""}

--- a/promoly-next/src/features/low_prices/components/HeroHighlight/index.tsx
+++ b/promoly-next/src/features/low_prices/components/HeroHighlight/index.tsx
@@ -10,42 +10,19 @@ type Props = {
 
 export default function HeroHighlight({ product }: Props) {
   return (
-    <section
-      className="
-        bg-[#0a154a]
-        rounded-2xl
-        p-4 sm:p-8 lg:p-12
-        border border-[#45C4B0]
-        shadow-lg
-        mb-16 sm:mb-20
-      "
-    >
-      <h2 className="text-xl sm:text-2xl lg:text-3xl font-bold text-[#9AEBA3] mb-6 sm:mb-10 flex items-center gap-3">
-        <span className="text-[#F5F138] text-2xl sm:text-3xl">🏆</span>
-        Maior Queda do Dia
+    <section className="bg-panel rounded-2xl p-4 sm:p-10 shadow-elevated border border-line">
+      <h2 className="text-2xl font-bold mb-8 flex items-center gap-2 text-ink">
+        🏆 Maior Queda do Dia
       </h2>
 
-      {/* BLOCO SUPERIOR */}
-      <div
-        className="
-    flex flex-col
-    gap-6
-    lg:grid lg:grid-cols-2
-    lg:gap-12
-    items-center lg:items-start
-    mb-8 sm:mb-12 lg:mb-16
-  "
-      >
+      <div className="grid md:grid-cols-2 gap-8 md:gap-12">
         <HeroImage product={product} />
-        <div className="flex flex-col gap-6">
+
+        <div>
           <HeroMetrics product={product} />
+          <HeroChart product={product} />
           <HeroActions product={product} />
         </div>
-      </div>
-
-      {/* GRÁFICO FULL WIDTH */}
-      <div className="mt-6 sm:mt-8">
-        <HeroChart product={product} />
       </div>
     </section>
   );

--- a/promoly-next/src/features/product/components/ProductCardSkeleton.tsx
+++ b/promoly-next/src/features/product/components/ProductCardSkeleton.tsx
@@ -1,21 +1,21 @@
 export default function ProductCardSkeleton() {
   return (
     <div className="
-      bg-surface
+      bg-panel
       rounded-xl2
       p-5
-      border border-gray-200
-      shadow-soft
+      border border-line
+      shadow-elevated
       animate-pulse
     ">
-      <div className="h-36 bg-gray-200 rounded-xl mb-5" />
+      <div className="h-36 bg-panel-subtle rounded-xl mb-5" />
 
-      <div className="h-4 bg-gray-200 rounded w-3/4 mb-3" />
-      <div className="h-4 bg-gray-200 rounded w-1/2 mb-6" />
+      <div className="h-4 bg-panel-subtle rounded w-3/4 mb-3" />
+      <div className="h-4 bg-panel-subtle rounded w-1/2 mb-6" />
 
       <div className="flex gap-3">
-        <div className="h-9 bg-gray-200 rounded-xl flex-1" />
-        <div className="h-9 bg-gray-200 rounded-xl flex-1" />
+        <div className="h-9 bg-panel-subtle rounded-xl flex-1" />
+        <div className="h-9 bg-panel-subtle rounded-xl flex-1" />
       </div>
     </div>
   );

--- a/promoly-next/src/features/product/components/ProductDetails.tsx
+++ b/promoly-next/src/features/product/components/ProductDetails.tsx
@@ -15,36 +15,27 @@ export default function ProductDetails({ product }: Props) {
   };
 
   return (
-    <div className="flex flex-col md:grid md:grid-cols-2 gap-8 md:gap-10 items-start">
-      {/* ================= IMAGEM ================= */}
-      <div className="bg-[#000D34] border border-[#45C4B0] rounded-3xl p-3 sm:p-6 md:p-8 flex items-center justify-center w-full">
+    <div className="grid md:grid-cols-2 gap-8 items-start">
+      {/* IMAGEM */}
+      <div className="bg-white rounded-3xl p-6 flex items-center justify-center">
         <Image
           src={product.imagem_url ?? "/placeholder.png"}
           alt={`Imagem do produto ${product.titulo}`}
-          width={1500}
-          height={1600}
+          width={1200}
+          height={1200}
           priority
-          className="
-      object-contain
-      w-full
-      h-auto
-      max-h-none        /* MOBILE sem limite */
-      md:max-h-[420px]  /* Desktop mantém */
-      transition-transform
-      duration-300
-      hover:scale-105
-    "
+          className="object-contain w-full h-auto max-h-[420px]"
         />
       </div>
 
-      {/* ================= INFORMAÇÕES ================= */}
-      <div className="flex flex-col gap-5 w-full">
-        <h1 className="text-xl sm:text-2xl md:text-3xl font-extrabold text-[#9AEBA3] leading-snug">
+      {/* INFORMAÇÕES */}
+      <div className="flex flex-col gap-4">
+        <h1 className="text-2xl font-bold text-ink leading-snug">
           {product.titulo}
         </h1>
 
         {product.preco !== null && (
-          <div className="text-3xl sm:text-4xl md:text-4xl font-extrabold text-[#F5F138]">
+          <div className="text-3xl font-extrabold text-success">
             {product.preco.toLocaleString("pt-BR", {
               style: "currency",
               currency: "BRL",
@@ -53,29 +44,26 @@ export default function ProductDetails({ product }: Props) {
         )}
 
         {product.descricao && (
-          <p className="text-[#45C4B0] text-sm leading-relaxed">
+          <p className="text-ink-muted text-sm leading-relaxed">
             {product.descricao}
           </p>
         )}
 
-        {/* ================= BOTÕES ================= */}
-        <div className="flex flex-col sm:flex-row gap-3 mt-4 w-full">
+        <div className="flex gap-3 mt-4 flex-wrap">
           {product.url_afiliada && (
             <a
               href={product.url_afiliada}
               target="_blank"
               rel="noopener noreferrer sponsored"
               className="
-                w-full
-                bg-[#F5F138]
-                hover:brightness-95
-                text-[#000D34]
-                font-bold
-                py-3
-                rounded-xl
+                bg-primary
+                hover:bg-primary-hover
+                text-white
+                font-semibold
+                px-6
+                py-2.5
+                rounded-xl2
                 transition
-                shadow-lg
-                text-center
               "
             >
               Comprar pelo menor preço
@@ -85,14 +73,14 @@ export default function ProductDetails({ product }: Props) {
           <button
             onClick={handleCopyLink}
             className="
-              w-full
-              bg-[#DAFDBA]
-              hover:bg-[#45C4B0]
-              text-[#000D34]
-              font-semibold
-              py-3
-              rounded-xl
+              bg-panel-subtle
+              text-ink-muted
+              hover:text-ink hover:bg-line
+              px-5
+              py-2.5
+              rounded-xl2
               transition
+              border border-line
             "
           >
             Copiar link

--- a/promoly-next/src/features/product/components/ProductHistory.tsx
+++ b/promoly-next/src/features/product/components/ProductHistory.tsx
@@ -39,31 +39,40 @@ export default function ProductHistory({
 
   if (previousPrice && lastPrice) {
     variationPercent = ((lastPrice - previousPrice) / previousPrice) * 100;
+
     variationValue = lastPrice - previousPrice;
 
     if (variationPercent > 0.2) trend = "alta";
     else if (variationPercent < -0.2) trend = "queda";
   }
 
-  const trendTextColor =
+  const trendColor =
     trend === "queda"
-      ? "text-[#F5F138]"
+      ? "text-success"
       : trend === "alta"
-        ? "text-red-400"
-        : "text-[#45C4B0]";
+        ? "text-danger"
+        : "text-ink-muted";
+
+  const chartColor =
+    trend === "queda" ? "#22c55e" : trend === "alta" ? "#ef4444" : "#94a3b8";
+
+  const gradientId = `priceGradient-${trend}`;
 
   return (
     <motion.div
-      className="mt-10 sm:mt-16"
+      className="mt-8 sm:mt-16"
       initial={{ opacity: 0, y: 30 }}
       whileInView={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.6, ease: "easeOut" }}
       viewport={{ once: true }}
     >
-      <h2 className="text-xl sm:text-3xl font-bold text-[#9AEBA3] mb-3">
+      <h2 className="text-lg sm:text-2xl font-bold text-ink mb-2 sm:mb-4">
         Histórico de preço
       </h2>
-      <p className={`text-sm sm:text-lg font-semibold mb-6 ${trendTextColor}`}>
+
+      <p
+        className={`text-sm sm:text-lg font-semibold mb-4 sm:mb-6 ${trendColor}`}
+      >
         {trend === "queda" && "⬇ "}
         {trend === "alta" && "⬆ "}
         {trend === "estabilidade" && "➖ "}
@@ -79,15 +88,19 @@ export default function ProductHistory({
            },
          )}) vs último registro`}
       </p>
-      <div className="bg-[#0b154a] border border-[#45C4B0] rounded-2xl p-3 sm:p-6 lg:p-8 shadow-lg">
-        <div className="w-full h-64 sm:h-80 lg:h-96 xl:h-[440px]">
+
+      <div className="bg-panel-subtle border border-line rounded-2xl p-3 sm:p-6 lg:p-8">
+        <div className="w-full h-48 sm:h-64 lg:h-80 xl:h-[420px]">
           <ResponsiveContainer width="100%" height="100%">
             <LineChart data={data}>
-              <CartesianGrid
-                strokeDasharray="3 3"
-                stroke="#45C4B0"
-                opacity={0.12}
-              />
+              <defs>
+                <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="0%" stopColor={chartColor} stopOpacity={0.35} />
+                  <stop offset="100%" stopColor={chartColor} stopOpacity={0} />
+                </linearGradient>
+              </defs>
+
+              <CartesianGrid strokeDasharray="3 3" stroke="#1f2a3d" vertical={false} />
 
               <XAxis
                 dataKey="data"
@@ -97,17 +110,13 @@ export default function ProductHistory({
                     month: "2-digit",
                   })
                 }
-                tick={{
-                  fill: "#45C4B0",
-                  fontSize: 11, // menor no mobile
-                  fontWeight: 600,
-                }}
-                minTickGap={15}
-                stroke="#45C4B0"
+                tick={{ fontSize: 10, fill: "#94a3b8" }}
+                axisLine={{ stroke: "#1f2a3d" }}
+                tickLine={false}
+                minTickGap={25}
               />
-
               <YAxis
-                width={70} // menos espaço lateral
+                width={80}
                 domain={[lowerDomain, upperDomain]}
                 tickFormatter={(value: number) =>
                   value.toLocaleString("pt-BR", {
@@ -116,22 +125,22 @@ export default function ProductHistory({
                     maximumFractionDigits: 0,
                   })
                 }
-                tick={{
-                  fill: "#45C4B0",
-                  fontSize: 11,
-                  fontWeight: 600,
-                }}
-                stroke="#45C4B0"
+                tick={{ fontSize: 12, fill: "#94a3b8" }}
+                axisLine={false}
+                tickLine={false}
               />
 
               <Tooltip
+                cursor={{ stroke: chartColor, strokeWidth: 1, strokeDasharray: "4 4" }}
                 contentStyle={{
-                  backgroundColor: "#000D34",
-                  border: "1px solid #45C4B0",
-                  borderRadius: "12px",
-                  color: "#9AEBA3",
-                  fontSize: "12px", // menor no mobile
+                  background: "#161d2e",
+                  border: "1px solid #1f2a3d",
+                  borderRadius: "0.75rem",
+                  color: "#f1f5f9",
+                  boxShadow: "0 10px 40px rgba(0,0,0,0.45)",
                 }}
+                labelStyle={{ color: "#94a3b8", marginBottom: 4 }}
+                itemStyle={{ color: "#f1f5f9" }}
                 formatter={(value: number | undefined) =>
                   value != null
                     ? value.toLocaleString("pt-BR", {
@@ -143,6 +152,7 @@ export default function ProductHistory({
                 labelFormatter={(label) => {
                   const date =
                     typeof label === "number" ? label : Number(label);
+
                   if (isNaN(date)) return "";
                   return new Date(date).toLocaleDateString("pt-BR");
                 }}
@@ -152,32 +162,21 @@ export default function ProductHistory({
                 type="stepAfter"
                 dataKey="preco"
                 stroke="none"
-                fill="#F5F138"
-                fillOpacity={0.06}
+                fill={`url(#${gradientId})`}
               />
 
               <Line
                 type="stepAfter"
                 dataKey="preco"
-                stroke="#F5F138"
+                stroke={chartColor}
                 strokeWidth={2.5}
-                dot={{
-                  r: 3.5, // tamanho base visível
-                  fill: "#F5F138",
-                  stroke: "#000D34", // cria contraste
-                  strokeWidth: 1.5,
-                }}
-                activeDot={{
-                  r: 6,
-                  fill: "#F5F138",
-                  stroke: "#000D34",
-                  strokeWidth: 2,
-                }}
+                dot={false}
+                activeDot={{ r: 5, strokeWidth: 0 }}
               />
             </LineChart>
           </ResponsiveContainer>
         </div>
-      </div>{" "}
+      </div>
     </motion.div>
   );
 }

--- a/promoly-next/src/features/product/components/ProductPriceAnalysis.tsx
+++ b/promoly-next/src/features/product/components/ProductPriceAnalysis.tsx
@@ -35,34 +35,31 @@ export default function ProductPriceAnalysis({ analytics, decision }: Props) {
   const diff = metrics.priceDiffPercent;
 
   return (
-    <div className="bg-[#0a154a] rounded-3xl border border-[#45C4B0] p-10 shadow-lg">
-      <h2 className="text-2xl font-extrabold mb-6 text-[#9AEBA3]">
+    <div>
+      <h2 className="text-lg sm:text-2xl font-bold mb-4 sm:mb-6 text-ink">
         💡 Análise inteligente de preço
       </h2>
 
-      <p className="text-4xl font-extrabold text-[#F5F138] mb-8">
+      <p className="text-3xl sm:text-4xl font-extrabold text-ink mb-6">
         {metrics.currentPrice.toLocaleString("pt-BR", {
           style: "currency",
           currency: "BRL",
         })}
       </p>
 
-      <div className="grid sm:grid-cols-2 gap-8 mb-10">
+      <div className="grid sm:grid-cols-2 gap-4 sm:gap-6 mb-6 sm:mb-8">
         {/* MÉDIA HISTÓRICA */}
-        <div className="bg-[#000D34] rounded-2xl p-6 border border-[#45C4B0]">
-          <p className="text-xs uppercase text-[#45C4B0] mb-2 font-semibold">
+        <div className="bg-panel-subtle rounded-2xl p-5 sm:p-6 border border-line">
+          <p className="text-xs uppercase tracking-wide text-ink-faint mb-2">
             Média histórica
           </p>
-
-          <p className="font-bold text-lg text-[#9AEBA3]">
+          <p className="font-semibold text-lg text-ink">
             {metrics.avgPrice.toLocaleString("pt-BR", {
               style: "currency",
               currency: "BRL",
             })}
           </p>
-
-          <p className="text-[#45C4B0] font-bold mt-2">
-            {diff > 0 ? "+" : ""}
+          <p className="text-success font-bold mt-2">
             {diff.toFixed(1)}% (
             {diffVsAverageValue.toLocaleString("pt-BR", {
               style: "currency",
@@ -74,23 +71,19 @@ export default function ProductPriceAnalysis({ analytics, decision }: Props) {
 
         {/* ÚLTIMO PREÇO */}
         {lastPrice && (
-          <div className="bg-[#000D34] rounded-2xl p-6 border border-[#45C4B0]">
-            <p className="text-xs uppercase text-[#45C4B0] mb-2 font-semibold">
+          <div className="bg-panel-subtle rounded-2xl p-5 sm:p-6 border border-line">
+            <p className="text-xs uppercase tracking-wide text-ink-faint mb-2">
               Último preço registrado
             </p>
-
-            <p className="font-bold text-lg text-[#9AEBA3]">
+            <p className="font-semibold text-lg text-ink">
               {lastPrice.toLocaleString("pt-BR", {
                 style: "currency",
                 currency: "BRL",
               })}
             </p>
-
             <p
               className={`font-bold mt-2 ${
-                variationVsLast > 0
-                  ? "text-[#F87171]" // vermelho suave
-                  : "text-[#45C4B0]"
+                variationVsLast > 0 ? "text-danger" : "text-success"
               }`}
             >
               {variationVsLast > 0 ? "+" : ""}
@@ -105,25 +98,22 @@ export default function ProductPriceAnalysis({ analytics, decision }: Props) {
         )}
       </div>
 
-      {/* BLOCO DECISÃO */}
-      <div className="rounded-2xl p-6 border border-[#45C4B0] bg-[#000D34]">
-        <p className="text-lg font-extrabold text-[#F5F138]">
+      <div className={`rounded-2xl p-5 sm:p-6 border ${decision.bg}`}>
+        <p className={`text-lg font-bold ${decision.color}`}>
           {decision.icon} {decision.title}
         </p>
 
-        <p className="text-sm mt-3 text-[#45C4B0] font-semibold">
-          {decision.description}
-        </p>
+        <p className="text-sm mt-3 text-ink-muted">{decision.description}</p>
 
         {variationVsLast > 0 && diff < 0 && (
-          <p className="text-sm mt-3 font-semibold text-[#9AEBA3]">
+          <p className="text-sm mt-3 font-medium text-ink">
             📈 O preço subiu recentemente, mas ainda permanece abaixo da média
             histórica.
           </p>
         )}
 
         {isLowestEver && (
-          <p className="text-sm mt-3 font-bold text-[#45C4B0]">
+          <p className="text-sm mt-3 font-semibold text-success">
             🎯 Este é o menor preço já registrado para este produto.
           </p>
         )}

--- a/promoly-next/src/features/product/components/ProductView.tsx
+++ b/promoly-next/src/features/product/components/ProductView.tsx
@@ -36,37 +36,36 @@ export default function ProductView({
   });
 
   return (
-    <div className="bg-[#000D34] min-h-screen">
+    <div className="bg-base min-h-screen">
       <JsonLd data={productSchema} />
       <JsonLd data={faqSchema} />
       <JsonLd data={breadcrumbSchema} />
 
-      <div className="max-w-7xl mx-auto px-6 py-16 grid lg:grid-cols-[2fr_1fr] gap-12">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 py-8 sm:py-14 grid lg:grid-cols-[2fr_1fr] gap-8 lg:gap-14">
         {/* ================= CONTEÚDO PRINCIPAL ================= */}
-        <section className="space-y-14">
-          {/* ================= PRODUTO ================= */}
-          <div className="bg-[#0a154a] rounded-3xl border border-[#45C4B0] p-8 shadow-lg">
+        <section className="space-y-6 sm:space-y-8">
+          {/* PRODUTO */}
+          <div className="bg-panel rounded-2xl sm:rounded-3xl shadow-elevated border border-line p-4 sm:p-8">
             <ProductDetails product={produto} />
           </div>
 
-          {/* ================= ANÁLISE ================= */}
-          <div className="bg-[#0a154a] rounded-3xl border border-[#45C4B0] p-8 shadow-lg">
+          {/* ANÁLISE */}
+          <div className="bg-panel rounded-2xl sm:rounded-3xl shadow-elevated border border-line p-4 sm:p-8">
             <ProductPriceAnalysis analytics={analytics} decision={decision} />
           </div>
 
-          {/* ================= INDICADORES ================= */}
-          <div className="bg-[#0a154a] rounded-3xl border border-[#45C4B0] p-8 shadow-lg">
-            <h2 className="text-2xl font-bold mb-8 text-[#9AEBA3]">
+          {/* INDICADORES */}
+          <div className="bg-panel rounded-2xl sm:rounded-3xl shadow-elevated border border-line p-4 sm:p-8">
+            <h2 className="text-lg sm:text-2xl font-bold mb-4 sm:mb-6 text-ink">
               📊 Indicadores de preço
             </h2>
 
-            <div className="grid grid-cols-1 sm:grid-cols-3 gap-6">
-              {/* MENOR PREÇO */}
-              <div className="bg-[#000D34] rounded-2xl p-6 border border-[#45C4B0]">
-                <p className="text-sm text-[#45C4B0] font-semibold mb-2">
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 sm:gap-6">
+              <div className="bg-success/10 rounded-xl sm:rounded-2xl p-4 sm:p-6 border border-success/30">
+                <p className="text-xs sm:text-sm text-success font-medium mb-1 sm:mb-2">
                   Menor preço histórico
                 </p>
-                <p className="text-2xl font-extrabold text-[#F5F138]">
+                <p className="text-lg sm:text-2xl font-bold text-success">
                   {analytics.metrics.minPrice.toLocaleString("pt-BR", {
                     style: "currency",
                     currency: "BRL",
@@ -74,12 +73,11 @@ export default function ProductView({
                 </p>
               </div>
 
-              {/* MAIOR PREÇO */}
-              <div className="bg-[#000D34] rounded-2xl p-6 border border-[#45C4B0]">
-                <p className="text-sm text-[#45C4B0] font-semibold mb-2">
+              <div className="bg-danger/10 rounded-xl sm:rounded-2xl p-4 sm:p-6 border border-danger/30">
+                <p className="text-xs sm:text-sm text-danger font-medium mb-1 sm:mb-2">
                   Maior preço histórico
                 </p>
-                <p className="text-2xl font-extrabold text-[#9AEBA3]">
+                <p className="text-lg sm:text-2xl font-bold text-danger">
                   {analytics.metrics.maxPrice.toLocaleString("pt-BR", {
                     style: "currency",
                     currency: "BRL",
@@ -87,20 +85,25 @@ export default function ProductView({
                 </p>
               </div>
 
-              {/* DECISÃO */}
-              <div className="bg-[#000D34] rounded-2xl p-6 border border-[#45C4B0]">
-                <p className="text-sm text-[#45C4B0] font-semibold mb-2">
+              <div
+                className={`rounded-xl sm:rounded-2xl p-4 sm:p-6 border ${decision.bg}`}
+              >
+                <p
+                  className={`text-xs sm:text-sm font-medium mb-1 sm:mb-2 ${decision.color}`}
+                >
                   Comparação com a média
                 </p>
-                <p className="text-xl font-bold text-[#F5F138]">
+                <p
+                  className={`text-base sm:text-xl font-bold ${decision.color}`}
+                >
                   {decision.title}
                 </p>
               </div>
             </div>
           </div>
 
-          {/* ================= HISTÓRICO ================= */}
-          <div className="bg-[#0a154a] rounded-3xl border border-[#45C4B0] p-8 shadow-lg">
+          {/* HISTÓRICO */}
+          <div className="bg-panel rounded-2xl sm:rounded-3xl shadow-elevated border border-line p-4 sm:p-8">
             <ProductHistory
               data={priceHistory}
               lowerDomain={analytics.metrics.lowerDomain}
@@ -111,10 +114,8 @@ export default function ProductView({
 
         {/* ================= SIDEBAR ================= */}
         <aside className="mt-12 lg:mt-0">
-          <div className="lg:sticky lg:top-28 space-y-8">
-            <div className="bg-[#0a154a] rounded-3xl border border-[#45C4B0] p-6 shadow-lg">
-              <SimilarProducts products={productData.similares} />
-            </div>
+          <div className="lg:sticky lg:top-28">
+            <SimilarProducts products={productData.similares} />
           </div>
         </aside>
       </div>

--- a/promoly-next/src/features/product/components/SimilarProducts.tsx
+++ b/promoly-next/src/features/product/components/SimilarProducts.tsx
@@ -12,26 +12,22 @@ export default function SimilarProducts({ products }: Props) {
   if (!products || products.length === 0) return null;
 
   return (
-    <aside className="bg-[#DAFDBA] rounded-3xl border border-[#45C4B0] p-6 shadow-lg">
-      <h3 className="text-lg font-bold mb-6 text-[#000D34] flex items-center gap-2">
+    <aside className="bg-panel rounded-3xl border border-line p-6 shadow-elevated">
+
+      <h3 className="text-lg font-semibold mb-6 text-ink flex items-center gap-2">
         🔁 Produtos semelhantes
       </h3>
 
-      <div className="flex flex-col gap-4">
+      <div className="flex flex-col gap-3">
+
         {products.map((p) => (
           <Link
             key={p.produto_id}
             href={`/produto/${p.slug}`}
-            className="
-              flex gap-4 p-4 rounded-xl
-              bg-white
-              border border-[#45C4B0]
-              hover:bg-[#CFF5A8]
-              transition
-            "
+            className="flex gap-4 p-3 rounded-xl transition border border-line bg-panel-subtle hover:bg-panel-elevated hover:border-primary/40"
           >
-            {/* IMAGEM */}
-            <div className="w-16 h-16 relative flex-shrink-0 bg-white rounded-lg p-2 border border-[#45C4B0]">
+
+            <div className="w-16 h-16 relative flex-shrink-0 bg-white rounded-lg p-2">
               <Image
                 src={p.imagem_url ?? "/placeholder.png"}
                 alt={p.titulo}
@@ -40,14 +36,13 @@ export default function SimilarProducts({ products }: Props) {
               />
             </div>
 
-            {/* TEXTO */}
             <div className="flex flex-col gap-1 flex-1">
-              <p className="text-sm font-semibold line-clamp-2 text-[#000D34]">
+              <p className="text-sm font-medium line-clamp-2 text-ink">
                 {p.titulo}
               </p>
 
               {p.preco !== null && (
-                <p className="text-[#000D34] font-bold text-sm">
+                <p className="text-success font-semibold text-sm">
                   {p.preco.toLocaleString("pt-BR", {
                     style: "currency",
                     currency: "BRL",
@@ -55,9 +50,12 @@ export default function SimilarProducts({ products }: Props) {
                 </p>
               )}
             </div>
+
           </Link>
         ))}
+
       </div>
+
     </aside>
   );
 }

--- a/promoly-next/src/features/product/utils/productDecision.ts
+++ b/promoly-next/src/features/product/utils/productDecision.ts
@@ -13,7 +13,7 @@ export function getPurchaseDecision(diff: number): PurchaseDecision {
       description:
         "O preço está muito abaixo da média histórica. Forte indicação de oportunidade.",
       color: "text-success",
-      bg: "bg-success-light border-success",
+      bg: "bg-success/10 border-success/40",
       icon: "🟢",
     };
   }
@@ -23,7 +23,7 @@ export function getPurchaseDecision(diff: number): PurchaseDecision {
       title: "Bom momento para comprar",
       description: "O preço está abaixo da média histórica.",
       color: "text-success",
-      bg: "bg-success-light border-success",
+      bg: "bg-success/10 border-success/40",
       icon: "🟢",
     };
   }
@@ -32,8 +32,8 @@ export function getPurchaseDecision(diff: number): PurchaseDecision {
     return {
       title: "Preço dentro da média",
       description: "O preço está alinhado com a média histórica.",
-      color: "text-gray-700",
-      bg: "bg-gray-100 border-gray-300",
+      color: "text-accent",
+      bg: "bg-accent/10 border-accent/40",
       icon: "🟡",
     };
   }
@@ -42,7 +42,7 @@ export function getPurchaseDecision(diff: number): PurchaseDecision {
     title: "Momento desfavorável para compra",
     description: "O preço está acima da média histórica.",
     color: "text-danger",
-    bg: "bg-red-50 border-danger",
+    bg: "bg-danger/10 border-danger/40",
     icon: "🔴",
   };
 }

--- a/promoly-next/tailwind.config.js
+++ b/promoly-next/tailwind.config.js
@@ -14,20 +14,21 @@ module.exports = {
         ========================== */
 
         primary: {
-          DEFAULT: "#2563eb",
-          hover: "#1d4ed8",
+          DEFAULT: "#3b82f6",
+          hover: "#2563eb",
         },
 
         success: {
-          DEFAULT: "#22c177",
+          DEFAULT: "#22c55e",
+          glow: "#34d399",
         },
 
         accent: {
-          DEFAULT: "#facc15",
+          DEFAULT: "#fbbf24",
         },
 
         danger: {
-          DEFAULT: "#dc2626",
+          DEFAULT: "#ef4444",
         },
 
         muted: {
@@ -38,11 +39,29 @@ module.exports = {
           DEFAULT: "#ffffff",
           subtle: "#f3f4f6",
         },
+
+        /* =========================
+           DARK PREMIUM SYSTEM
+        ========================== */
+        base: "#0a0e1a",
+        panel: {
+          DEFAULT: "#111726",
+          elevated: "#161d2e",
+          subtle: "#1c2435",
+        },
+        ink: {
+          DEFAULT: "#f1f5f9",
+          muted: "#94a3b8",
+          faint: "#64748b",
+        },
+        line: "#1f2a3d",
       },
 
       boxShadow: {
         soft: "0 4px 12px rgba(0,0,0,0.05)",
         medium: "0 8px 20px rgba(0,0,0,0.08)",
+        glow: "0 0 0 1px rgba(34,197,94,0.25), 0 8px 30px rgba(34,197,94,0.12)",
+        elevated: "0 10px 40px rgba(0,0,0,0.45)",
       },
 
       borderRadius: {


### PR DESCRIPTION
## Resumo
Rework de UI/UX do `promoly-next` para tema **dark premium** (BG slate, cards elevados, acento azul + verde neon, gráficos com gradient). Cobre Home, página de produto, gráficos e todas as listagens (categoria / menor-preço / low_prices).

## Mudanças
**Design system**
- `tailwind`: tokens dark (`base`/`panel`/`ink`/`line`), sombras `glow`/`elevated`, success neon + glow
- `globals.css`: base dark, scrollbar/selection, smooth scroll

**Home**
- hero com glow + badge tempo-real + 2 CTAs
- grid de métricas (ofertas, maior queda, queda média, oportunidades)
- categorias em cards com ícone; cards de produto dark

**Produto + gráficos**
- `ProductView`/`Details`/`PriceAnalysis`/`SimilarProducts` dark
- `ProductHistory` (recharts): gradient fill, eixos legíveis, tooltip dark, cores neon verde/vermelho
- **fix(Next 16):** `params` virou Promise — faltava `await` em `produto/[slug]` (quebrava com "Cannot read split")
- `productDecision`: classes inexistentes (`bg-success-light`/`bg-red-50`) trocadas por tints `*/10`

**Listagens**
- `LowPricesView`, `CategoryLowPricesView`, `categoria/[slug]`, `menor-preco`
- `HeroHighlight`, `CategorySections`, `FAQSection`, `CategoryFilters`, paginação e skeletons dark
- imagens sempre em chip branco; removido `console.log` de debug

## Notas
- Base = `fix/scraper-ratelimiter-thread-safety` (branch UI saiu dela). Diff = 1 commit.
- `next build` passou (TS + 7/7 static pages, sem erros).

🤖 Generated with [Claude Code](https://claude.com/claude-code)