### PR TITLE
refactor(affiliate): desacopla worker da UI PT-BR do linkbuilder (#11)

### DIFF
--- a/affiliate/mlb_affiliate.py
+++ b/affiliate/mlb_affiliate.py
@@ -1,3 +1,4 @@
+import os
 import time
 
 from selenium.webdriver.common.by import By
@@ -15,6 +16,38 @@ LINK_BUILDER_URL = "https://www.mercadolivre.com.br/afiliados/linkbuilder#hub"
 # Tempo máximo de espera pelo link afiliado aparecer no resultado.
 RESULT_TIMEOUT = 15
 
+# =========================
+# Seletores configuráveis (desacoplados da UI PT-BR do linkbuilder)
+# =========================
+
+# ID do textarea onde a URL do produto é colada. Pode mudar conforme a UI
+# do Mercado Livre; configurável via env var.
+LINKBUILDER_TEXTAREA_ID = os.getenv("LINKBUILDER_TEXTAREA_ID", "url-0")
+
+# Textos do botão "Gerar". A UI é PT-BR por padrão, mas mantemos uma lista
+# de fallbacks multilíngues para resiliência. Aceita lista separada por
+# vírgula via env var (ex.: "Gerar,Generate,Generar").
+LINKBUILDER_GERAR_TEXTS = [
+    t.strip()
+    for t in os.getenv("LINKBUILDER_GERAR_TEXTS", "Gerar,Generate").split(",")
+    if t.strip()
+]
+
+
+def _xpath_botao_gerar(textos) -> str:
+    """
+    Constrói um XPath que casa um <span> cujo texto normalizado seja igual
+    a qualquer um dos textos fornecidos (fallback multilíngue).
+    """
+    condicoes = " or ".join(
+        f"normalize-space()='{texto}'" for texto in textos
+    )
+    return f"//span[{condicoes}]"
+
+
+# =========================
+# Driver
+# =========================
 
 # create_driver é reexportado de affiliate.driver (fonte única) para manter
 # compatibilidade com quem importa de affiliate.mlb_affiliate.
@@ -29,7 +62,7 @@ def gerar_link_afiliado(driver, wait, produto_url: str) -> str | None:
     driver.get(LINK_BUILDER_URL)
 
     textarea_produto = wait.until(
-        EC.presence_of_element_located((By.ID, "url-0"))
+        EC.presence_of_element_located((By.ID, LINKBUILDER_TEXTAREA_ID))
     )
 
     # 🔥 remove tooltips do Andes UI (causa do click interceptado)
@@ -51,12 +84,25 @@ def gerar_link_afiliado(driver, wait, produto_url: str) -> str | None:
     textarea_produto.send_keys(Keys.ENTER)
     driver.find_element(By.TAG_NAME, "body").click()
 
-    # botão Gerar
-    botao_gerar = wait.until(
-        EC.presence_of_element_located(
-            (By.XPATH, "//span[normalize-space()='Gerar']")
+    # botão Gerar — tenta cada texto da lista de fallback (multilíngue).
+    # Constrói um único XPath cobrindo todos os textos configurados.
+    if not LINKBUILDER_GERAR_TEXTS:
+        raise ValueError(
+            "Nenhum texto configurado para o botão 'Gerar' "
+            "(LINKBUILDER_GERAR_TEXTS vazio)."
         )
-    )
+
+    xpath_gerar = _xpath_botao_gerar(LINKBUILDER_GERAR_TEXTS)
+    try:
+        botao_gerar = wait.until(
+            EC.presence_of_element_located((By.XPATH, xpath_gerar))
+        )
+    except Exception as exc:
+        raise RuntimeError(
+            "Botão 'Gerar' não encontrado no linkbuilder. "
+            f"Textos tentados: {LINKBUILDER_GERAR_TEXTS}. "
+            "Verifique a env var LINKBUILDER_GERAR_TEXTS ou se a UI mudou."
+        ) from exc
 
     driver.execute_script(
         "arguments[0].scrollIntoView({block: 'center'});",

--- a/tests/unit/test_linkbuilder_decoupling.py
+++ b/tests/unit/test_linkbuilder_decoupling.py
@@ -1,0 +1,167 @@
+"""
+Testes de desacoplamento do worker de afiliado em relação à UI PT-BR
+do linkbuilder do Mercado Livre.
+
+Cobre:
+(a) seletores configuráveis por env var são usados;
+(b) fallback de múltiplos textos do botão "Gerar";
+(c) retorno do link quando extrair_link_afiliado devolve um link;
+(d) comportamento quando o botão "Gerar" não é encontrado.
+"""
+
+import importlib
+
+import pytest
+from unittest.mock import MagicMock
+
+import affiliate.mlb_affiliate as mlb
+
+
+@pytest.fixture
+def driver():
+    """Driver Selenium mockado."""
+    drv = MagicMock(name="driver")
+    drv.page_source = "<html>conteúdo</html>"
+    return drv
+
+
+@pytest.fixture
+def wait():
+    """WebDriverWait mockado; .until() devolve um elemento mockado."""
+    w = MagicMock(name="wait")
+    w.until.return_value = MagicMock(name="elemento")
+    return w
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep(mocker):
+    """Evita esperas reais durante os testes."""
+    mocker.patch.object(mlb.time, "sleep")
+
+
+def _recarrega_modulo():
+    """Recarrega o módulo para reavaliar as constantes lidas de env."""
+    return importlib.reload(mlb)
+
+
+# ---------------------------------------------------------------------------
+# (a) Seletores configuráveis por env var
+# ---------------------------------------------------------------------------
+
+def test_textarea_id_configuravel_por_env(monkeypatch, driver, wait, mocker):
+    monkeypatch.setenv("LINKBUILDER_TEXTAREA_ID", "campo-custom")
+    mod = _recarrega_modulo()
+    mocker.patch.object(mod, "extrair_link_afiliado", return_value=None)
+    # espiona o construtor de condição para inspecionar os locators usados
+    spy = mocker.spy(mod.EC, "presence_of_element_located")
+
+    assert mod.LINKBUILDER_TEXTAREA_ID == "campo-custom"
+
+    mod.gerar_link_afiliado(driver, wait, "https://produto")
+
+    # primeira condição deve localizar o textarea pelo ID custom
+    primeiro_locator = spy.call_args_list[0].args[0]
+    assert primeiro_locator[1] == "campo-custom"
+
+    monkeypatch.delenv("LINKBUILDER_TEXTAREA_ID")
+    _recarrega_modulo()
+
+
+def test_gerar_texts_configuravel_por_env(monkeypatch):
+    monkeypatch.setenv("LINKBUILDER_GERAR_TEXTS", "Gerar, Generate ,Generar")
+    mod = _recarrega_modulo()
+
+    assert mod.LINKBUILDER_GERAR_TEXTS == ["Gerar", "Generate", "Generar"]
+
+    monkeypatch.delenv("LINKBUILDER_GERAR_TEXTS")
+    _recarrega_modulo()
+
+
+# ---------------------------------------------------------------------------
+# (b) Fallback de múltiplos textos do botão
+# ---------------------------------------------------------------------------
+
+def test_xpath_botao_cobre_multiplos_idiomas():
+    mod = _recarrega_modulo()
+    xpath = mod._xpath_botao_gerar(["Gerar", "Generate"])
+    assert "normalize-space()='Gerar'" in xpath
+    assert "normalize-space()='Generate'" in xpath
+    assert " or " in xpath
+
+
+def test_botao_gerar_usa_xpath_com_textos_configurados(
+    monkeypatch, driver, wait, mocker
+):
+    monkeypatch.setenv("LINKBUILDER_GERAR_TEXTS", "Gerar,Generate")
+    mod = _recarrega_modulo()
+    mocker.patch.object(mod, "extrair_link_afiliado", return_value=None)
+    spy = mocker.spy(mod.EC, "presence_of_element_located")
+
+    mod.gerar_link_afiliado(driver, wait, "https://produto")
+
+    # segunda condição localiza o botão "Gerar" via XPath multilíngue
+    locator = spy.call_args_list[1].args[0]
+    assert locator[0].lower() == "xpath"
+    assert "Gerar" in locator[1]
+    assert "Generate" in locator[1]
+
+    monkeypatch.delenv("LINKBUILDER_GERAR_TEXTS")
+    _recarrega_modulo()
+
+
+# ---------------------------------------------------------------------------
+# (c) Retorno do link
+# ---------------------------------------------------------------------------
+
+def test_retorna_link_quando_extrator_devolve_link(driver, wait, mocker):
+    mod = _recarrega_modulo()
+    mocker.patch.object(
+        mod, "extrair_link_afiliado", return_value="https://mercadolivre.com/sec/abc"
+    )
+
+    link = mod.gerar_link_afiliado(driver, wait, "https://produto")
+
+    assert link == "https://mercadolivre.com/sec/abc"
+
+
+def test_retorna_none_quando_extrator_devolve_none(driver, wait, mocker):
+    mod = _recarrega_modulo()
+    mocker.patch.object(mod, "extrair_link_afiliado", return_value=None)
+
+    link = mod.gerar_link_afiliado(driver, wait, "https://produto")
+
+    assert link is None
+
+
+# ---------------------------------------------------------------------------
+# (d) Botão não encontrado
+# ---------------------------------------------------------------------------
+
+def test_erro_claro_quando_botao_nao_encontrado(driver, mocker):
+    mod = _recarrega_modulo()
+    mocker.patch.object(mod, "extrair_link_afiliado", return_value=None)
+
+    wait = MagicMock(name="wait")
+    elemento_textarea = MagicMock(name="textarea")
+
+    # primeira chamada (.until p/ textarea) ok; segunda (.until p/ botão) falha
+    wait.until.side_effect = [elemento_textarea, Exception("timeout")]
+
+    with pytest.raises(RuntimeError) as exc:
+        mod.gerar_link_afiliado(driver, wait, "https://produto")
+
+    assert "Gerar" in str(exc.value)
+
+
+def test_erro_quando_lista_de_textos_vazia(monkeypatch, driver, wait, mocker):
+    monkeypatch.setenv("LINKBUILDER_GERAR_TEXTS", " , ")
+    mod = _recarrega_modulo()
+    mocker.patch.object(mod, "extrair_link_afiliado", return_value=None)
+
+    assert mod.LINKBUILDER_GERAR_TEXTS == []
+
+    with pytest.raises(ValueError):
+        mod.gerar_link_afiliado(driver, wait, "https://produto")
+
+    monkeypatch.delenv("LINKBUILDER_GERAR_TEXTS")
+    _recarrega_modulo()


### PR DESCRIPTION
## Contexto

Ponto **#11** da issue #52: reduzir o acoplamento do worker de afiliado à UI PT-BR do linkbuilder do Mercado Livre.

## Mudanças

- Extrai seletores de `affiliate/mlb_affiliate.py` para constantes configuráveis por env var:
  - `LINKBUILDER_TEXTAREA_ID` (default `"url-0"`)
  - `LINKBUILDER_GERAR_TEXTS` (default lista `["Gerar","Generate"]`, aceita CSV via env)
- Botão "Gerar": XPath multilíngue construído a partir da lista de fallback; erro claro (`RuntimeError`) quando nenhum texto bate, e `ValueError` quando a lista está vazia.
- Captura do link por regex mantida como estava (já robusta).
- Sem alteração na assinatura pública de `gerar_link_afiliado` nem em `LINK_BUILDER_URL`.
- Novos testes unitários em `tests/unit/test_linkbuilder_decoupling.py` (pytest + pytest-mock).
- `requirements.txt`: adiciona `pytest-mock>=3.12.0` e `factory-boy>=3.3.0`.

## Testes

`python -m pytest tests/unit/test_linkbuilder_decoupling.py -q` → 8 passed.
Suíte unit completa: apenas 2 falhas pré-existentes na branch `dev` (scraper, não relacionadas).

## Checklist

- [x] Código/comentários em PT-BR
- [x] Conventional commit
- [x] Coberto por testes
- [x] Sem breaking change
- [x] Sintaxe validada
- [ ] Revisão pendente

Refs #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)