### PR TITLE
fix(web): build resiliente quando a API está offline no prerender

### DIFF
--- a/promoly-next/src/app/menor-preco-hoje/page.tsx
+++ b/promoly-next/src/app/menor-preco-hoje/page.tsx
@@ -3,10 +3,12 @@ import { enrichProducts } from "@/features/low_prices/utils/enrichProducts";
 import LowPriceView from "@/features/low_prices/LowPricesView";
 
 export default async function MenorPrecoHojePage() {
+  // Degrada para lista vazia se a API estiver indisponível no build/prerender.
+  // O ISR repreenche quando a API voltar; até lá, renderiza o estado vazio.
   const products = await fetchProducts({
     order: "desconto",
     limit: 40,
-  });
+  }).catch(() => []);
 
   const enriched = await enrichProducts(products);
 

--- a/promoly-next/src/app/page.tsx
+++ b/promoly-next/src/app/page.tsx
@@ -68,10 +68,12 @@ export const metadata: Metadata = {
 export const revalidate = 60;
 
 export default async function HomePage() {
+  // Degrada para lista vazia se a API estiver indisponível no build/prerender.
+  // O ISR (revalidate) repreenche assim que a API voltar.
   const products: ProductCardData[] = await fetchProducts({
     order: "desconto",
     limit: 20,
-  });
+  }).catch(() => []);
 
   const unique = Array.from(
     new Map(products.map((p) => [p.produto_id, p])).values(),

--- a/promoly-next/src/app/sitemap.ts
+++ b/promoly-next/src/app/sitemap.ts
@@ -4,9 +4,17 @@ import { fetchAllProducts, fetchAllCategories } from "@/lib/api";
 const BASE_URL =
   process.env.NEXT_PUBLIC_SITE_URL || "https://promoly-core.vercel.app/";
 
+// Gera o sitemap em runtime (request-time), nunca em build.
+// Evita que a indisponibilidade da API durante o build quebre o deploy.
+export const dynamic = "force-dynamic";
+
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const products = await fetchAllProducts();
-  const categories = await fetchAllCategories();
+  // Se a API estiver indisponível, degrada para um sitemap mínimo
+  // em vez de derrubar a renderização da rota.
+  const [products, categories] = await Promise.all([
+    fetchAllProducts().catch(() => []),
+    fetchAllCategories().catch(() => []),
+  ]);
 
   const now = new Date();
 


### PR DESCRIPTION
## Problema

O build do Next falhava ao pré-renderizar `/sitemap.xml`, `/` e `/menor-preco-hoje`: o `fetch` para a API (fallback `localhost:8080`) era **recusado em build time**, derrubando o deploy do Vercel em **todas as PRs abertas e em produção**.

```
Error occurred prerendering page "/sitemap.xml"
TypeError: fetch failed ... connect ECONNREFUSED 127.0.0.1:8080
```

## Fix

Build deixa de depender da API; degrada com elegância e o ISR repreenche quando a API volta.

- `sitemap.ts`: `export const dynamic = "force-dynamic"` (gera em runtime, nunca em build) + fetch com fallback para sitemap mínimo.
- `page.tsx` e `menor-preco-hoje/page.tsx`: `fetchProducts(...).catch(() => [])` → renderiza estado vazio em vez de quebrar; o `revalidate` (ISR) repreenche.

## Verificação

- `npm run build` ✅ verde com a API offline (antes: exit 1).
- Rotas: `/` e `/menor-preco-hoje` static+ISR; `/sitemap.xml` e `[slug]` dinâmicas.

> ⚠️ Nota de infra: o fallback de `NEXT_PUBLIC_API_URL` é `http://localhost:8080`. Garantir que `NEXT_PUBLIC_API_URL` esteja setada no Vercel apontando pra API Railway, senão as páginas renderizam vazias em runtime (build já não quebra).

