### PR TITLE
fix(web): build resiliente quando a API está offline no prerender (main)

### DIFF
--- a/promoly-next/src/app/menor-preco-hoje/page.tsx
+++ b/promoly-next/src/app/menor-preco-hoje/page.tsx
@@ -4,10 +4,12 @@ import LowPriceView from "@/features/low_prices/LowPricesView";
 import type { EnrichedProduct } from "@/types";
 
 export default async function MenorPrecoHojePage() {
+  // Degrada para lista vazia se a API estiver indisponível no build/prerender.
+  // O ISR repreenche quando a API voltar; até lá, renderiza o estado vazio.
   const products = await fetchProducts({
     order: "desconto",
     limit: 40,
-  });
+  }).catch(() => []);
 
   const enriched = await enrichProducts(products);
 

--- a/promoly-next/src/app/page.tsx
+++ b/promoly-next/src/app/page.tsx
@@ -68,10 +68,12 @@ export const metadata: Metadata = {
 export const revalidate = 60;
 
 export default async function HomePage() {
+  // Degrada para lista vazia se a API estiver indisponível no build/prerender.
+  // O ISR (revalidate) repreenche assim que a API voltar.
   const products: ProductCardData[] = await fetchProducts({
     order: "desconto",
     limit: 20,
-  });
+  }).catch(() => []);
 
   const unique = Array.from(
     new Map(products.map((p) => [p.produto_id, p])).values(),

--- a/promoly-next/src/app/sitemap.ts
+++ b/promoly-next/src/app/sitemap.ts
@@ -4,9 +4,17 @@ import { fetchAllProducts, fetchAllCategories } from "@/lib/api";
 const BASE_URL =
   process.env.NEXT_PUBLIC_SITE_URL || "https://promoly-core.vercel.app/";
 
+// Gera o sitemap em runtime (request-time), nunca em build.
+// Evita que a indisponibilidade da API durante o build quebre o deploy.
+export const dynamic = "force-dynamic";
+
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const products = await fetchAllProducts();
-  const categories = await fetchAllCategories();
+  // Se a API estiver indisponível, degrada para um sitemap mínimo
+  // em vez de derrubar a renderização da rota.
+  const [products, categories] = await Promise.all([
+    fetchAllProducts().catch(() => []),
+    fetchAllCategories().catch(() => []),
+  ]);
 
   const now = new Date();
 


### PR DESCRIPTION
Mesmo fix da #61, aplicado sobre `main` (produção).

## Problema
Build do Next falhava ao pré-renderizar `/sitemap.xml`, `/` e `/menor-preco-hoje` — `fetch` para a API recusado em build time (`ECONNREFUSED 127.0.0.1:8080`), derrubando o Vercel em **produção** e em todas as PRs.

## Fix
- `sitemap.ts`: `force-dynamic` + fallback para sitemap mínimo.
- `page.tsx` / `menor-preco-hoje`: `fetch(...).catch(() => [])`; ISR repreenche depois.

## Verificação (sobre main)
- `npm run lint` ✅
- `npm run build` ✅ verde com API offline.

> ⚠️ Setar `NEXT_PUBLIC_API_URL` no Vercel (fallback é `localhost:8080`), senão páginas renderizam vazias em runtime.

