### PR TITLE
ci: roda scraper no GitHub Actions no lugar do cron local

### DIFF
--- a/.github/workflows/db-setup.yml
+++ b/.github/workflows/db-setup.yml
@@ -1,0 +1,34 @@
+name: DB setup (migrations + seed)
+
+# Rodar manualmente uma vez depois de criar o banco novo, e sempre que
+# entrar migration nova. Nao roda sozinho de proposito: mexe em schema.
+on:
+  workflow_dispatch:
+
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    env:
+      DATABASE_URL: ${{ secrets.DATABASE_URL }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Instala dependencias
+        run: pip install -r requirements.txt
+
+      - name: Aplica migrations
+        run: alembic upgrade head
+
+      - name: Popula categorias e plataformas
+        run: python -m database.seed_db
+
+      - name: Popula subcategorias
+        run: python -m database.seed_subcat

--- a/.github/workflows/scraper.yml
+++ b/.github/workflows/scraper.yml
@@ -1,0 +1,50 @@
+name: Scraper Mercado Livre
+
+on:
+  schedule:
+    # 06:00 e 18:00 em America/Sao_Paulo (runner usa UTC, UTC-3)
+    - cron: "0 9,21 * * *"
+  workflow_dispatch:
+
+# Substitui o flock do run_scrapping.sh: duas execucoes nunca se cruzam.
+concurrency:
+  group: promoly-scraper
+  cancel-in-progress: false
+
+jobs:
+  scrape:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # Equivalente ao arquivo .pipeline_disabled: commitar esse arquivo
+      # na raiz desliga o pipeline sem mexer no workflow.
+      - name: Verifica flag de desligamento
+        id: flag
+        run: |
+          if [ -f .pipeline_disabled ]; then
+            echo "Pipeline desativado por .pipeline_disabled"
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/setup-python@v5
+        if: steps.flag.outputs.enabled == 'true'
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Instala dependencias
+        if: steps.flag.outputs.enabled == 'true'
+        run: pip install -r requirements.txt
+
+      - name: Roda scraper
+        if: steps.flag.outputs.enabled == 'true'
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          URL_MLB_BASE: ${{ vars.URL_MLB_BASE }}
+          SCRAPER_ENABLED_CATEGORIES: ${{ vars.SCRAPER_ENABLED_CATEGORIES }}
+        run: python -m scrapper_mlb.main

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,6 +35,7 @@ typing-extensions>=4.9.0
 alembic==1.13.1
 SQLAlchemy>=2.0
 psycopg2-binary>=2.9
+python-slugify>=8.0.0  # database/seed_subcat.py
 
 
 # =========================


### PR DESCRIPTION
## Contexto

O deploy do Railway foi desligado. Hoje nada executa o pipeline: `run_scrapping.sh` dependia de `flock`, caminho absoluto e Docker na máquina do dev, e o banco de produção foi junto. O front (`promoly-core.vercel.app`) continua no ar, responde 200 e renderiza o layout, mas sem nenhum produto — zero ocorrências de `R$` no HTML.

Este PR devolve a execução do scraper sem servidor e sem custo: repo público tem minutos ilimitados de Actions.

## O que muda

**`.github/workflows/scraper.yml`** — cron 06:00 e 18:00 America/Sao_Paulo (`0 9,21 * * *`, runner em UTC) + `workflow_dispatch`.

Equivalências com o `run_scrapping.sh`:

| Antes | Agora |
|---|---|
| `flock` no `/tmp` | `concurrency: promoly-scraper` |
| teste de `.pipeline_disabled` | step de guarda com o mesmo arquivo |
| `docker compose run --rm scraper` | `python -m scrapper_mlb.main` |

Sem Docker de propósito: `scrapper_mlb` é HTTP puro (requests/bs4/lxml), não usa Selenium. Construir imagem a cada run só somaria minutos.

**`.github/workflows/db-setup.yml`** — apenas `workflow_dispatch`. `alembic upgrade head` + `database.seed_db` + `database.seed_subcat`. Fora do cron por mexer em schema.

**`requirements.txt`** — adiciona `python-slugify`. `database/seed_subcat.py` importa `from slugify import slugify` e o pacote não estava listado; o seed quebraria no CI.

## Configuração necessária antes do primeiro run

- Secret `DATABASE_URL`
- Variables `URL_MLB_BASE` e `SCRAPER_ENABLED_CATEGORIES`

## Pontos de atenção

1. **O cron só dispara na branch default.** GitHub ignora `schedule:` fora da `main` — enquanto este PR não for mergeado, só o botão manual funciona.

2. **`database/seed_db.py` semeia 3 categorias** (`eletronicos`, `casa`, `pet`), mas `scrapper_mlb/config.py` define 9. As outras 6 caem no `⚠️ Categoria não encontrada no banco` e são puladas em silêncio. Fora do escopo deste PR; dá pra contornar com `SCRAPER_ENABLED_CATEGORIES=eletronicos,casa,pet` ou derivar o seed de `CATEGORIES`.

3. **`scrapper_mlb/main.py` abre uma conexão por produto** e `get_connection()` cria um engine novo a cada chamada (`database/db.py`). Barato com Postgres local, caro com Postgres gerenciado — é um handshake TLS por produto. Recomendo apontar a `DATABASE_URL` para o endpoint **pooled** do provedor, sem alterar código.

4. Cron em repo público é desabilitado automaticamente após 60 dias sem commit.

## Teste

YAML validado. O scraper em si só pode ser exercitado com a `DATABASE_URL` configurada — plano é rodar `db-setup` manual, depois `scraper` manual, e conferir se entrou produto antes de subir a API.