### PR TITLE
release: hardening do scraping, redesign dark e volta do structured data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,13 @@ media/
 # Pytest / coverage
 .pytest_cache/
 cover/
+.coverage
+.coverage.*
+coverage.xml
+htmlcov/
+
+# Dados gerados localmente
+data/
 
 # Translations
 *.mo

--- a/affiliate/driver.py
+++ b/affiliate/driver.py
@@ -1,17 +1,24 @@
+import os
+
 from selenium import webdriver
 from selenium.webdriver.chrome.options import Options
 
 
+# Perfil persistente do Chrome usado pelo worker de afiliado.
+# Configurável por ambiente para não ficar preso a um caminho de máquina.
+DEFAULT_PROFILE_DIR = os.path.expanduser("~/selenium-chromium-profile")
+
+
 def create_driver():
+    profile_dir = os.getenv("SELENIUM_PROFILE_DIR", DEFAULT_PROFILE_DIR)
+    profile_name = os.getenv("SELENIUM_PROFILE_NAME", "Default")
+
     options = Options()
 
-    options.add_argument(
-        "--user-data-dir=/home/leandro/selenium-chromium-profile"
-    )
-    options.add_argument("--profile-directory=Default")
+    options.add_argument(f"--user-data-dir={profile_dir}")
+    options.add_argument(f"--profile-directory={profile_name}")
 
     options.add_argument("--start-maximized")
     options.add_argument("--disable-blink-features=AutomationControlled")
 
     return webdriver.Chrome(options=options)
-    

--- a/affiliate/main.py
+++ b/affiliate/main.py
@@ -17,6 +17,10 @@ SLEEP_SEM_TRABALHO = 30
 SLEEP_ENTRE_LINKS = 3
 WAIT_TIMEOUT = 40
 
+# Reinicia o driver a cada N links para evitar degradação/vazamento de
+# memória do Chrome/Selenium em sessões longas.
+RESTART_DRIVER_EVERY = 100
+
 
 
 # =========================
@@ -34,6 +38,18 @@ def handle_shutdown(signum, frame):
 
 signal.signal(signal.SIGINT, handle_shutdown)
 signal.signal(signal.SIGTERM, handle_shutdown)
+
+
+def restart_driver(driver):
+    """Encerra o driver atual e devolve um novo driver + wait."""
+    try:
+        driver.quit()
+    except Exception:
+        pass
+
+    novo_driver = create_driver()
+    novo_wait = WebDriverWait(novo_driver, WAIT_TIMEOUT)
+    return novo_driver, novo_wait
 
 
 # =========================
@@ -56,6 +72,7 @@ def main():
     try:
         driver = create_driver()
         wait = WebDriverWait(driver, WAIT_TIMEOUT)
+        links_processados = 0
 
         while not shutdown_requested:
             # 🔁 conexão NOVA para cada batch
@@ -114,6 +131,16 @@ def main():
                         conn.commit()
 
                     time.sleep(SLEEP_ENTRE_LINKS)
+
+                    # 🔄 Reinicia o driver periodicamente (evita degradação
+                    # de memória do Selenium em sessões longas).
+                    links_processados += 1
+                    if links_processados % RESTART_DRIVER_EVERY == 0:
+                        print(
+                            f"🔄 {links_processados} links processados — "
+                            "reiniciando driver..."
+                        )
+                        driver, wait = restart_driver(driver)
 
             finally:
                 conn.close()

--- a/affiliate/mlb_affiliate.py
+++ b/affiliate/mlb_affiliate.py
@@ -1,36 +1,20 @@
 import time
-import re
 
-from selenium import webdriver
-from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 
+from affiliate.driver import create_driver
 from affiliate.utils.affiliate_link import extrair_link_afiliado
 
 
 LINK_BUILDER_URL = "https://www.mercadolivre.com.br/afiliados/linkbuilder#hub"
 
 
-# =========================
-# Driver
-# =========================
-
-def create_driver():
-    options = Options()
-
-    # PROFILE CLONADO (não usar o do snap diretamente)
-    options.add_argument(
-        "--user-data-dir=/home/leandro/selenium-chromium-profile"
-    )
-    options.add_argument("--profile-directory=Default")
-
-    options.add_argument("--start-maximized")
-    options.add_argument("--disable-blink-features=AutomationControlled")
-
-    return webdriver.Chrome(options=options)
+# create_driver é reexportado de affiliate.driver (fonte única) para manter
+# compatibilidade com quem importa de affiliate.mlb_affiliate.
+__all__ = ["create_driver", "gerar_link_afiliado"]
 
 
 # =========================

--- a/affiliate/mlb_affiliate.py
+++ b/affiliate/mlb_affiliate.py
@@ -4,12 +4,16 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
+from selenium.common.exceptions import TimeoutException
 
 from affiliate.driver import create_driver
 from affiliate.utils.affiliate_link import extrair_link_afiliado
 
 
 LINK_BUILDER_URL = "https://www.mercadolivre.com.br/afiliados/linkbuilder#hub"
+
+# Tempo máximo de espera pelo link afiliado aparecer no resultado.
+RESULT_TIMEOUT = 15
 
 
 # create_driver é reexportado de affiliate.driver (fonte única) para manter
@@ -58,17 +62,18 @@ def gerar_link_afiliado(driver, wait, produto_url: str) -> str | None:
         "arguments[0].scrollIntoView({block: 'center'});",
         botao_gerar
     )
-    time.sleep(0.5)
+    time.sleep(0.5)  # breve settle após scrollIntoView antes do click via JS
     driver.execute_script("arguments[0].click();", botao_gerar)
 
-    # espera curta
-    time.sleep(2)
+    # 🔍 espera o link afiliado realmente aparecer (em vez de sleep fixo)
+    try:
+        WebDriverWait(driver, RESULT_TIMEOUT).until(
+            lambda d: extrair_link_afiliado(d.page_source) is not None
+        )
+    except TimeoutException:
+        return None  # link não foi gerado a tempo
 
-    # 🔍 captura por regex (robusto)
-    html = driver.page_source
-    link = extrair_link_afiliado(html)
-
-    return link  # pode ser None se inválido
+    return extrair_link_afiliado(driver.page_source)
 
 
 # =========================

--- a/affiliate/mlb_affiliate.py
+++ b/affiliate/mlb_affiliate.py
@@ -1,3 +1,4 @@
+import os
 import time
 
 from selenium.webdriver.common.by import By
@@ -15,6 +16,38 @@ LINK_BUILDER_URL = "https://www.mercadolivre.com.br/afiliados/linkbuilder#hub"
 # Tempo máximo de espera pelo link afiliado aparecer no resultado.
 RESULT_TIMEOUT = 15
 
+# =========================
+# Seletores configuráveis (desacoplados da UI PT-BR do linkbuilder)
+# =========================
+
+# ID do textarea onde a URL do produto é colada. Pode mudar conforme a UI
+# do Mercado Livre; configurável via env var.
+LINKBUILDER_TEXTAREA_ID = os.getenv("LINKBUILDER_TEXTAREA_ID", "url-0")
+
+# Textos do botão "Gerar". A UI é PT-BR por padrão, mas mantemos uma lista
+# de fallbacks multilíngues para resiliência. Aceita lista separada por
+# vírgula via env var (ex.: "Gerar,Generate,Generar").
+LINKBUILDER_GERAR_TEXTS = [
+    t.strip()
+    for t in os.getenv("LINKBUILDER_GERAR_TEXTS", "Gerar,Generate").split(",")
+    if t.strip()
+]
+
+
+def _xpath_botao_gerar(textos) -> str:
+    """
+    Constrói um XPath que casa um <span> cujo texto normalizado seja igual
+    a qualquer um dos textos fornecidos (fallback multilíngue).
+    """
+    condicoes = " or ".join(
+        f"normalize-space()='{texto}'" for texto in textos
+    )
+    return f"//span[{condicoes}]"
+
+
+# =========================
+# Driver
+# =========================
 
 # create_driver é reexportado de affiliate.driver (fonte única) para manter
 # compatibilidade com quem importa de affiliate.mlb_affiliate.
@@ -29,7 +62,7 @@ def gerar_link_afiliado(driver, wait, produto_url: str) -> str | None:
     driver.get(LINK_BUILDER_URL)
 
     textarea_produto = wait.until(
-        EC.presence_of_element_located((By.ID, "url-0"))
+        EC.presence_of_element_located((By.ID, LINKBUILDER_TEXTAREA_ID))
     )
 
     # 🔥 remove tooltips do Andes UI (causa do click interceptado)
@@ -51,12 +84,25 @@ def gerar_link_afiliado(driver, wait, produto_url: str) -> str | None:
     textarea_produto.send_keys(Keys.ENTER)
     driver.find_element(By.TAG_NAME, "body").click()
 
-    # botão Gerar
-    botao_gerar = wait.until(
-        EC.presence_of_element_located(
-            (By.XPATH, "//span[normalize-space()='Gerar']")
+    # botão Gerar — tenta cada texto da lista de fallback (multilíngue).
+    # Constrói um único XPath cobrindo todos os textos configurados.
+    if not LINKBUILDER_GERAR_TEXTS:
+        raise ValueError(
+            "Nenhum texto configurado para o botão 'Gerar' "
+            "(LINKBUILDER_GERAR_TEXTS vazio)."
         )
-    )
+
+    xpath_gerar = _xpath_botao_gerar(LINKBUILDER_GERAR_TEXTS)
+    try:
+        botao_gerar = wait.until(
+            EC.presence_of_element_located((By.XPATH, xpath_gerar))
+        )
+    except Exception as exc:
+        raise RuntimeError(
+            "Botão 'Gerar' não encontrado no linkbuilder. "
+            f"Textos tentados: {LINKBUILDER_GERAR_TEXTS}. "
+            "Verifique a env var LINKBUILDER_GERAR_TEXTS ou se a UI mudou."
+        ) from exc
 
     driver.execute_script(
         "arguments[0].scrollIntoView({block: 'center'});",

--- a/promoly-next/src/app/categoria/[slug]/page.tsx
+++ b/promoly-next/src/app/categoria/[slug]/page.tsx
@@ -7,7 +7,8 @@ import type { Metadata } from "next";
 const LIMIT = 12;
 
 const BASE_URL =
-  process.env.NEXT_PUBLIC_API_URL || "https://promoly-core.vercel.app";
+  process.env.NEXT_PUBLIC_API_URL ||
+  "https://promoly-core.vercel.app";
 
 /* =====================================================
    🔥 METADATA DINÂMICA
@@ -20,6 +21,7 @@ export async function generateMetadata({
   params: Promise<{ slug: string }>;
   searchParams: Promise<{ page?: string }>;
 }): Promise<Metadata> {
+
   const { slug } = await params;
   const resolvedSearchParams = await searchParams;
 
@@ -36,6 +38,7 @@ export async function generateMetadata({
     },
   };
 }
+
 
 /* =====================================================
    🔥 PAGE
@@ -121,8 +124,10 @@ export default async function CategoryPage(props: {
       },
     ],
   };
+
   return (
-    <div className="bg-[#000D34] min-h-screen">
+    <div className="bg-base min-h-screen">
+
       {/* 🔥 STRUCTURED DATA */}
       <script
         type="application/ld+json"
@@ -130,6 +135,7 @@ export default async function CategoryPage(props: {
           __html: JSON.stringify(itemListSchema),
         }}
       />
+
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{
@@ -137,41 +143,41 @@ export default async function CategoryPage(props: {
         }}
       />
 
-      <div className="max-w-7xl mx-auto px-6 py-16">
-        {/* ================= HERO HEADER ================= */}
-        <header className="mb-16 text-center">
-          <h1 className="text-3xl sm:text-4xl md:text-5xl font-extrabold text-[#9AEBA3] leading-tight">
-            Ofertas em <span className="text-[#F5F138] capitalize">{slug}</span>
+      <div className="max-w-7xl mx-auto px-4 py-10">
+
+        {/* HEADER */}
+        <div className="mb-6">
+          <h1 className="text-3xl font-bold text-ink capitalize">
+            {slug}
           </h1>
 
-          <p className="text-[#45C4B0] mt-4 text-lg font-semibold">
-            {total} produtos encontrados com histórico de preço
+          <p className="text-sm text-ink-muted mt-1">
+            {total} produtos encontrados
           </p>
-        </header>
-
-        {/* ================= FILTROS ================= */}
-        <div className="mb-14">
-          <CategoryFilters />
         </div>
 
-        {/* ================= GRID ================= */}
+        {/* FILTROS */}
+        <CategoryFilters />
+
+        {/* GRID */}
         {products.length === 0 ? (
-          <div className="text-center mt-20">
-            <p className="text-[#45C4B0] text-lg font-semibold">
-              Nenhum produto encontrado.
-            </p>
-          </div>
+          <p className="text-ink-muted mt-6">
+            Nenhum produto encontrado
+          </p>
         ) : (
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-10">
+          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-6 mt-6">
             {products.map((p) => (
-              <ProductCard key={p.produto_id} product={p} />
+              <ProductCard
+                key={p.produto_id}
+                product={p}
+              />
             ))}
           </div>
         )}
 
-        {/* ================= PAGINAÇÃO ================= */}
+        {/* PAGINAÇÃO */}
         {totalPages > 1 && (
-          <div className="flex justify-center gap-4 mt-20 flex-wrap">
+          <div className="flex justify-center gap-2 mt-12 flex-wrap">
             {Array.from({ length: totalPages }).map((_, i) => {
               const pageNumber = i + 1;
               const isActive = page === pageNumber;
@@ -187,10 +193,10 @@ export default async function CategoryPage(props: {
                       order,
                     },
                   }}
-                  className={`px-5 py-2.5 rounded-xl text-sm font-bold transition ${
+                  className={`px-4 py-2 rounded-lg text-sm font-semibold transition ${
                     isActive
-                      ? "bg-[#F5F138] text-[#000D34] shadow-lg"
-                      : "bg-[#0a154a] text-[#DAFDBA] border border-[#45C4B0] hover:bg-[#45C4B0] hover:text-[#000D34]"
+                      ? "bg-primary text-white"
+                      : "bg-panel text-ink-muted border border-line hover:bg-success hover:text-[#052e16] hover:border-success"
                   }`}
                 >
                   {pageNumber}
@@ -199,6 +205,7 @@ export default async function CategoryPage(props: {
             })}
           </div>
         )}
+
       </div>
     </div>
   );

--- a/promoly-next/src/app/globals.css
+++ b/promoly-next/src/app/globals.css
@@ -7,11 +7,37 @@
 ========================= */
 
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
+  --background: #0a0e1a;
+  --foreground: #f1f5f9;
+}
+
+html {
+  scroll-behavior: smooth;
 }
 
 body {
   background: var(--background);
   color: var(--foreground);
+  -webkit-font-smoothing: antialiased;
+}
+
+::selection {
+  background: rgba(34, 197, 94, 0.3);
+  color: #f1f5f9;
+}
+
+/* subtle scrollbar for dark theme */
+::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+::-webkit-scrollbar-track {
+  background: #0a0e1a;
+}
+::-webkit-scrollbar-thumb {
+  background: #1f2a3d;
+  border-radius: 999px;
+}
+::-webkit-scrollbar-thumb:hover {
+  background: #2b3a52;
 }

--- a/promoly-next/src/app/menor-preco-hoje/page.tsx
+++ b/promoly-next/src/app/menor-preco-hoje/page.tsx
@@ -3,10 +3,12 @@ import { enrichProducts } from "@/features/low_prices/utils/enrichProducts";
 import LowPriceView from "@/features/low_prices/LowPricesView";
 
 export default async function MenorPrecoHojePage() {
+  // Degrada para lista vazia se a API estiver indisponível no build/prerender.
+  // O ISR repreenche quando a API voltar; até lá, renderiza o estado vazio.
   const products = await fetchProducts({
     order: "desconto",
     limit: 40,
-  });
+  }).catch(() => []);
 
   const enriched = await enrichProducts(products);
 

--- a/promoly-next/src/app/page.tsx
+++ b/promoly-next/src/app/page.tsx
@@ -68,10 +68,12 @@ export const metadata: Metadata = {
 export const revalidate = 60;
 
 export default async function HomePage() {
+  // Degrada para lista vazia se a API estiver indisponível no build/prerender.
+  // O ISR (revalidate) repreenche assim que a API voltar.
   const products: ProductCardData[] = await fetchProducts({
     order: "desconto",
     limit: 20,
-  });
+  }).catch(() => []);
 
   const unique = Array.from(
     new Map(products.map((p) => [p.produto_id, p])).values(),

--- a/promoly-next/src/app/page.tsx
+++ b/promoly-next/src/app/page.tsx
@@ -150,12 +150,32 @@ export default async function HomePage() {
   };
 
   const categories = [
-    { label: "Eletrônicos", slug: "eletronicos" },
-    { label: "Casa", slug: "casa" },
-    { label: "Pet", slug: "pet" },
-    { label: "Games", slug: "games" },
-    { label: "Fitness", slug: "fitness" },
-    { label: "Automotivo", slug: "automotivo" },
+    { label: "Eletrônicos", slug: "eletronicos", icon: "💻" },
+    { label: "Casa", slug: "casa", icon: "🏠" },
+    { label: "Pet", slug: "pet", icon: "🐾" },
+    { label: "Games", slug: "games", icon: "🎮" },
+    { label: "Fitness", slug: "fitness", icon: "🏋️" },
+    { label: "Automotivo", slug: "automotivo", icon: "🚗" },
+  ];
+
+  /* ===== MÉTRICAS DA HOME ===== */
+  const discounts = ranked
+    .map((p) => ("desconto_pct" in p ? (p.desconto_pct ?? 0) : 0))
+    .filter((d: number) => d > 0);
+
+  const maxDiscount = discounts.length ? Math.max(...discounts) : 0;
+  const avgDiscount = discounts.length
+    ? Math.round(discounts.reduce((a, b) => a + b, 0) / discounts.length)
+    : 0;
+  const belowAvgCount = ranked.filter(
+    (p) => ("desconto_pct" in p ? (p.desconto_pct ?? 0) : 0) >= 15,
+  ).length;
+
+  const stats = [
+    { label: "Ofertas monitoradas", value: ranked.length, accent: "text-ink" },
+    { label: "Maior queda hoje", value: `${maxDiscount}%`, accent: "text-success" },
+    { label: "Queda média", value: `${avgDiscount}%`, accent: "text-primary" },
+    { label: "Oportunidades", value: belowAvgCount, accent: "text-accent" },
   ];
 
   return (
@@ -187,38 +207,83 @@ export default async function HomePage() {
         }}
       />
 
-      <div className="bg-[#000D34] min-h-screen">
-        <div className="max-w-7xl mx-auto px-6 py-16">
-          {/* HERO */}
+      <div className="bg-base min-h-screen">
+        {/* glow de fundo do hero */}
+        <div className="relative overflow-hidden">
+          <div
+            aria-hidden
+            className="pointer-events-none absolute -top-32 left-1/2 -translate-x-1/2 h-[420px] w-[820px] max-w-full rounded-full bg-primary/20 blur-[140px]"
+          />
 
-          <section className="text-center mb-20">
-            <h1 className="text-4xl sm:text-5xl font-extrabold text-[#9AEBA3] mb-6">
-              Compare preços e encontre o{" "}
-              <span className="text-[#F5F138]">menor valor</span> antes de
-              comprar
-            </h1>
+          <div className="relative max-w-7xl mx-auto px-4 sm:px-6 pt-16 pb-12 sm:pt-24">
+            {/* HERO */}
+            <section className="text-center max-w-3xl mx-auto">
+              <span className="inline-flex items-center gap-2 text-xs font-semibold text-ink-muted bg-panel border border-line rounded-full px-4 py-1.5 mb-6">
+                <span className="h-2 w-2 rounded-full bg-success animate-pulse" />
+                Monitorando preços em tempo real
+              </span>
 
-            <p className="text-[#45C4B0] max-w-2xl mx-auto text-lg mb-8">
-              Acompanhe o histórico real de preços e descubra quando um produto
-              está abaixo da média histórica.
-            </p>
+              <h1 className="text-3xl sm:text-5xl font-extrabold text-ink leading-tight mb-5">
+                Compre no <span className="text-success">menor preço</span>,
+                <br className="hidden sm:block" /> sem cair em falsa promoção
+              </h1>
 
-            <Link
-              href="/menor-preco-hoje"
-              className="inline-block bg-[#45C4B0] hover:bg-[#9AEBA3] text-[#000D34] font-semibold px-8 py-3 rounded-xl shadow-medium transition"
-            >
-              🔥 Ver melhores ofertas
-            </Link>
-          </section>
+              <p className="text-ink-muted max-w-xl mx-auto text-base sm:text-lg mb-8">
+                Acompanhe o histórico real de preços e descubra quando um produto
+                está de fato abaixo da média histórica.
+              </p>
 
+              <div className="flex flex-col sm:flex-row gap-3 justify-center">
+                <Link
+                  href="/menor-preco-hoje"
+                  className="inline-flex items-center justify-center bg-success hover:bg-success-glow text-[#052e16] text-base font-bold px-8 py-3 rounded-xl shadow-glow transition"
+                >
+                  🔥 Ver melhores ofertas
+                </Link>
+                <Link
+                  href="/categoria/eletronicos"
+                  className="inline-flex items-center justify-center bg-panel hover:bg-panel-subtle text-ink border border-line font-semibold px-8 py-3 rounded-xl transition"
+                >
+                  Explorar categorias
+                </Link>
+              </div>
+            </section>
+
+            {/* MÉTRICAS */}
+            <section className="grid grid-cols-2 lg:grid-cols-4 gap-3 sm:gap-4 mt-12 sm:mt-16">
+              {stats.map((s) => (
+                <div
+                  key={s.label}
+                  className="bg-panel border border-line rounded-2xl p-4 sm:p-6 text-center"
+                >
+                  <div className={`text-2xl sm:text-3xl font-extrabold ${s.accent}`}>
+                    {s.value}
+                  </div>
+                  <div className="text-xs sm:text-sm text-ink-muted mt-1">
+                    {s.label}
+                  </div>
+                </div>
+              ))}
+            </section>
+          </div>
+        </div>
+
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 pb-16">
           {/* TOP OPORTUNIDADES */}
+          <section className="mb-16 sm:mb-20">
+            <div className="flex items-end justify-between mb-6 sm:mb-8">
+              <h2 className="text-xl sm:text-2xl font-bold text-ink">
+                🔥 Top oportunidades de hoje
+              </h2>
+              <Link
+                href="/menor-preco-hoje"
+                className="text-sm font-medium text-ink-muted hover:text-success transition shrink-0"
+              >
+                Ver todas →
+              </Link>
+            </div>
 
-          <section className="mb-24">
-            <h2 className="text-3xl font-bold text-[#9AEBA3] mb-10">
-              🔥 Top oportunidades de hoje
-            </h2>
-
-            <div className="grid grid-cols-1 sm:grid-cols-1 lg:grid-cols-3 gap-8">
+            <div className="grid grid-cols-2 lg:grid-cols-3 gap-3 sm:gap-6">
               {ranked.slice(0, 3).map((p) => (
                 <ProductCard key={`${p.produto_id}-top`} product={p} />
               ))}
@@ -226,46 +291,46 @@ export default async function HomePage() {
           </section>
 
           {/* CATEGORIAS */}
-
-          <section className="mb-24">
-            <h2 className="text-2xl font-bold text-[#9AEBA3] mb-8">
+          <section className="mb-16 sm:mb-20">
+            <h2 className="text-xl sm:text-2xl font-bold text-ink mb-6">
               Navegue por categorias
             </h2>
 
-            <div className="flex flex-wrap gap-4">
+            <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3">
               {categories.map((cat) => (
                 <Link
                   key={cat.slug}
                   href={`/categoria/${cat.slug}`}
-                  className="px-6 py-2.5 bg-[#DAFDBA] text-[#000D34] rounded-full text-sm font-semibold hover:bg-[#45C4B0] transition shadow-soft"
+                  className="group flex flex-col items-center gap-2 bg-panel border border-line rounded-2xl px-4 py-5 text-center hover:border-primary/50 hover:bg-panel-elevated transition"
                 >
-                  {cat.label}
+                  <span className="text-2xl">{cat.icon}</span>
+                  <span className="text-sm font-medium text-ink-muted group-hover:text-ink transition">
+                    {cat.label}
+                  </span>
                 </Link>
               ))}
             </div>
           </section>
 
           {/* GRID */}
-
           <section>
-            <h2 className="text-3xl font-bold text-[#9AEBA3] mb-10">
+            <h2 className="text-xl sm:text-2xl font-bold text-ink mb-6 sm:mb-8">
               Ofertas em destaque
             </h2>
 
-            <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-4 lg:gap-8">
+            <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 sm:gap-5 lg:grid-cols-4 lg:gap-6">
               {ranked.map((p) => (
                 <ProductCard key={`${p.produto_id}-grid`} product={p} />
               ))}
             </div>
           </section>
 
-          {/* SEO TEXT */}
-
-          <section className="mt-24 text-[#45C4B0] max-w-3xl">
-            <h2 className="text-2xl font-bold mb-4 text-[#9AEBA3]">
+          {/* SEO TEXTO */}
+          <section className="mt-20 max-w-3xl">
+            <h2 className="text-xl sm:text-2xl font-bold text-ink mb-4">
               Como encontrar o menor preço online?
             </h2>
-            <p>
+            <p className="text-ink-muted leading-relaxed">
               O PromoLy é um comparador de preços que analisa o histórico de
               valores e identifica oportunidades reais. Antes de comprar,
               verifique se o preço atual está abaixo da média histórica.

--- a/promoly-next/src/app/produto/[slug]/loading.tsx
+++ b/promoly-next/src/app/produto/[slug]/loading.tsx
@@ -1,37 +1,37 @@
 export default function Loading() {
   return (
-    <div className="g-zinc-950 min-h-screen">
+    <div className="bg-base min-h-screen">
       <div className="max-w-7xl mx-auto px-4 py-10">
         <div className="grid lg:grid-cols-[2fr_1fr] gap-10">
           {/* MAIN */}
           <div className="space-y-8">
             {/* CARD PRINCIPAL */}
-            <div className="bg-white text-white rounded-2xl shadow-sm border border-gray-100 p-8 animate-pulse">
+            <div className="bg-panel rounded-2xl border border-line p-8 animate-pulse">
               <div className="grid md:grid-cols-2 gap-10">
-                <div className="bg-gray-200 rounded-xl h-80"></div>
+                <div className="bg-panel-subtle rounded-xl h-80"></div>
 
                 <div className="space-y-4">
-                  <div className="h-6 bg-gray-200 rounded w-3/4"></div>
-                  <div className="h-4 bg-gray-200 rounded w-1/4"></div>
-                  <div className="h-10 bg-gray-200 rounded w-1/2"></div>
-                  <div className="h-12 bg-gray-200 rounded w-1/3"></div>
+                  <div className="h-6 bg-panel-subtle rounded w-3/4"></div>
+                  <div className="h-4 bg-panel-subtle rounded w-1/4"></div>
+                  <div className="h-10 bg-panel-subtle rounded w-1/2"></div>
+                  <div className="h-12 bg-panel-subtle rounded w-1/3"></div>
                 </div>
               </div>
             </div>
 
             {/* HISTÓRICO */}
-            <div className="bg-white rounded-2xl shadow-sm border border-gray-100 p-8 animate-pulse">
-              <div className="h-6 bg-gray-200 rounded w-1/3 mb-6"></div>
-              <div className="h-64 bg-gray-200 rounded-xl"></div>
+            <div className="bg-panel rounded-2xl border border-line p-8 animate-pulse">
+              <div className="h-6 bg-panel-subtle rounded w-1/3 mb-6"></div>
+              <div className="h-64 bg-panel-subtle rounded-xl"></div>
             </div>
           </div>
 
           {/* ASIDE */}
-          <div className="bg-white rounded-2xl shadow-sm border border-gray-100 p-6 animate-pulse space-y-4">
-            <div className="h-5 bg-gray-200 rounded w-1/2"></div>
-            <div className="h-20 bg-gray-200 rounded-xl"></div>
-            <div className="h-20 bg-gray-200 rounded-xl"></div>
-            <div className="h-20 bg-gray-200 rounded-xl"></div>
+          <div className="bg-panel rounded-2xl border border-line p-6 animate-pulse space-y-4">
+            <div className="h-5 bg-panel-subtle rounded w-1/2"></div>
+            <div className="h-20 bg-panel-subtle rounded-xl"></div>
+            <div className="h-20 bg-panel-subtle rounded-xl"></div>
+            <div className="h-20 bg-panel-subtle rounded-xl"></div>
           </div>
         </div>
       </div>

--- a/promoly-next/src/app/produto/[slug]/page.tsx
+++ b/promoly-next/src/app/produto/[slug]/page.tsx
@@ -7,126 +7,80 @@ const BASE_URL =
   process.env.NEXT_PUBLIC_API_URL || "https://promoly-core.vercel.app";
 
 type Props = {
-  params: Promise<{
-    slug?: string;
-  }>;
+  params: Promise<{ slug: string }>;
 };
 
-/* =========================
-   Função utilitária segura
-========================= */
-function extractIdFromSlug(slug?: string): number | null {
-  if (!slug) return null;
-
-  const idPart = slug.split("-").pop();
-  if (!idPart) return null;
-
-  const id = Number(idPart);
-  return isNaN(id) ? null : id;
-}
-
-/* =========================
-   METADATA
-========================= */
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
-  try {
-    const resolvedParams = await params;
-    const slug = resolvedParams?.slug;
-    const id = extractIdFromSlug(slug);
+  const { slug } = await params;
 
-    if (!slug || !id) {
-      return {};
-    }
-
-    const productData = await fetchProductById(id);
-
-    if (!productData?.produto) {
-      return {};
-    }
-
-    const produto = productData.produto;
-
-    const price =
-      produto.preco != null
-        ? produto.preco.toLocaleString("pt-BR", {
-            style: "currency",
-            currency: "BRL",
-          })
-        : null;
-
-    return {
-      title: produto.titulo,
-      description: price
-        ? `Veja histórico de preço e descubra se vale a pena comprar por ${price}.`
-        : "Veja histórico completo no Promoly.",
-      openGraph: {
-        title: produto.titulo,
-        description: price
-          ? `Atualmente por ${price}. Veja histórico completo no Promoly.`
-          : "Veja histórico completo no Promoly.",
-        url: `${BASE_URL}/produto/${slug}`,
-        images: [
-          {
-            url: produto.imagem_url ?? "/og-image.jpg",
-            width: 1200,
-            height: 630,
-            alt: produto.titulo,
-          },
-        ],
-      },
-      twitter: {
-        card: "summary_large_image",
-        title: produto.titulo,
-        description: price
-          ? `Atualmente por ${price}. Veja histórico completo.`
-          : "Veja histórico completo.",
-        images: [produto.imagem_url ?? "/og-image.jpg"],
-      },
-    };
-  } catch (error) {
-    console.error("Erro em generateMetadata:", error);
+  if (!slug) {
     return {};
   }
-}
 
-/* =========================
-   PAGE
-========================= */
-export default async function ProductPage({ params }: Props) {
-  const resolvedParams = await params;
+  const id = Number(slug.split("-").pop());
 
-  const slug = resolvedParams?.slug;
-  const id = extractIdFromSlug(slug);
-
-  if (!slug || !id) {
-    notFound();
+  if (isNaN(id)) {
+    return {};
   }
 
-  let productData;
-  let prices;
-
-  try {
-    [productData, prices] = await Promise.all([
-      fetchProductById(id),
-      fetchPrices(id),
-    ]);
-  } catch (error) {
-    console.error("Erro ao buscar dados:", error);
-    notFound();
-  }
+  const productData = await fetchProductById(id);
 
   if (!productData?.produto) {
-    notFound();
+    return {};
   }
 
-  const priceHistory = Array.isArray(prices)
-    ? prices
-        .map((p) => ({
-          preco: Number(p.preco),
-          data: new Date(p.created_at).getTime(),
-        }))
-        .sort((a, b) => a.data - b.data)
-    : [];
+  const produto = productData.produto;
+
+  const price = produto.preco?.toLocaleString("pt-BR", {
+    style: "currency",
+    currency: "BRL",
+  });
+
+  return {
+    title: produto.titulo,
+    description: `Veja histórico de preço e descubra se vale a pena comprar por ${price}.`,
+    openGraph: {
+      title: produto.titulo,
+      description: `Atualmente por ${price}. Veja histórico completo no Promoly.`,
+      url: `${BASE_URL}/produto/${slug}`,
+      images: [
+        {
+          url: produto.imagem_url ?? "/og-image.jpg",
+          width: 1200,
+          height: 630,
+          alt: produto.titulo,
+        },
+      ],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: produto.titulo,
+      description: `Atualmente por ${price}. Veja histórico completo.`,
+      images: [produto.imagem_url ?? "/og-image.jpg"],
+    },
+  };
+}
+
+export default async function ProductPage({ params }: Props) {
+  const { slug } = await params;
+
+  const id = Number(slug.split("-").pop());
+
+  if (isNaN(id)) notFound();
+
+  const [productData, prices] = await Promise.all([
+    fetchProductById(id),
+    fetchPrices(id),
+  ]);
+
+  if (!productData?.produto) notFound();
+
+  const priceHistory = prices
+    .map((p) => ({
+      preco: Number(p.preco),
+      data: new Date(p.created_at).getTime(),
+    }))
+    .sort((a, b) => a.data - b.data);
 
   return (
     <ProductView

--- a/promoly-next/src/app/sitemap.ts
+++ b/promoly-next/src/app/sitemap.ts
@@ -4,9 +4,17 @@ import { fetchAllProducts, fetchAllCategories } from "@/lib/api";
 const BASE_URL =
   process.env.NEXT_PUBLIC_SITE_URL || "https://promoly-core.vercel.app/";
 
+// Gera o sitemap em runtime (request-time), nunca em build.
+// Evita que a indisponibilidade da API durante o build quebre o deploy.
+export const dynamic = "force-dynamic";
+
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const products = await fetchAllProducts();
-  const categories = await fetchAllCategories();
+  // Se a API estiver indisponível, degrada para um sitemap mínimo
+  // em vez de derrubar a renderização da rota.
+  const [products, categories] = await Promise.all([
+    fetchAllProducts().catch(() => []),
+    fetchAllCategories().catch(() => []),
+  ]);
 
   const now = new Date();
 

--- a/promoly-next/src/components/ProductCard.tsx
+++ b/promoly-next/src/components/ProductCard.tsx
@@ -37,31 +37,41 @@ export default function ProductCard({ product, priority = false }: Props) {
   return (
     <article
       className="
-    relative
-    bg-[#0a154a]
-    rounded-2xl
-    border border-[#45C4B0]
-    shadow-lg
-    hover:shadow-2xl
-    transition-all duration-300
-    hover:-translate-y-1
-    hover:border-[#F5F138]
-    p-6
-    flex flex-col
-    group
-  "
+        relative
+        bg-panel
+        rounded-xl2
+        border border-line
+        shadow-elevated
+        hover:border-success/40
+        hover:shadow-glow
+        transition-all duration-300
+        hover:-translate-y-1
+        p-4 sm:p-5
+        flex flex-col
+        group
+      "
     >
-      {/* BADGE DESCONTO */}
-      {isDeal && product.desconto_pct != null && (
-        <span className="absolute top-4 left-4 bg-[#F5F138] text-[#000D34] text-xs font-extrabold px-3 py-1 rounded-full shadow-md z-10">
-          -{product.desconto_pct}% OFF
-        </span>
-      )}
+      {/* BADGES TOPO */}
+      <div className="absolute top-3 left-3 right-3 z-10 flex items-start justify-between pointer-events-none">
+        {isDeal && product.desconto_pct != null ? (
+          <span className="bg-success/15 text-success ring-1 ring-success/30 text-xs font-bold px-2.5 py-1 rounded-full backdrop-blur-sm">
+            −{product.desconto_pct}%
+          </span>
+        ) : (
+          <span />
+        )}
+
+        {showOpportunity && (
+          <span className="bg-accent/15 text-accent ring-1 ring-accent/30 text-xs font-semibold px-2.5 py-1 rounded-full backdrop-blur-sm">
+            🔥 Oportunidade
+          </span>
+        )}
+      </div>
 
       {/* IMAGEM */}
       <Link
         href={productUrl}
-        className="bg-[#000D34] rounded-xl p-4 flex items-center justify-center overflow-hidden"
+        className="bg-white rounded-xl p-4 sm:p-5 flex items-center justify-center overflow-hidden"
       >
         <Image
           src={product.imagem_url ?? "/placeholder.png"}
@@ -70,60 +80,43 @@ export default function ProductCard({ product, priority = false }: Props) {
           height={500}
           priority={priority}
           loading={priority ? "eager" : "lazy"}
-          className="
-        w-full
-        h-auto
-        object-contain
-        aspect-[4/5]
-        sm:aspect-[3/4]
-        scale-110
-        group-hover:scale-[1.18]
-        transition-transform
-        duration-300
-      "
+          className="w-full h-auto object-contain aspect-[4/5] sm:aspect-[3/4] group-hover:scale-105 transition-transform duration-300"
           sizes="
-        (max-width: 640px) 100vw,
-        (max-width: 1024px) 33vw,
-        300px
-      "
+      (max-width: 640px) 50vw,
+      (max-width: 1024px) 33vw,
+      300px
+    "
         />
       </Link>
 
       {/* CONTEÚDO */}
-      <div className="mt-6 flex flex-col gap-3 flex-1">
+      <div className="mt-4 flex flex-col gap-2 flex-1">
         {/* TÍTULO */}
         <Link
           href={productUrl}
-          className="
-        text-base
-        font-semibold
-        text-[#9AEBA3]
-        line-clamp-2
-        hover:text-[#F5F138]
-        transition
-      "
+          className="text-sm sm:text-base font-semibold text-white line-clamp-2 hover:text-success transition min-h-[2.5rem]"
         >
           {product.titulo}
         </Link>
 
         {/* PREÇO */}
-        <div className="flex flex-col">
+        <div className="flex flex-col mt-auto">
           {isDeal ? (
             <>
               {product.preco_anterior != null && (
-                <span className="text-sm text-[#45C4B0] line-through">
+                <span className="text-xs text-ink-faint line-through">
                   R$ {Number(product.preco_anterior).toFixed(2)}
                 </span>
               )}
 
               {product.preco_atual != null && (
-                <span className="text-3xl font-extrabold text-[#F5F138]">
+                <span className="text-xl sm:text-2xl font-extrabold text-success">
                   R$ {Number(product.preco_atual).toFixed(2)}
                 </span>
               )}
             </>
           ) : (
-            <span className="text-3xl font-extrabold text-[#F5F138]">
+            <span className="text-xl sm:text-2xl font-extrabold text-ink">
               {"preco" in product && product.preco != null
                 ? `R$ ${Number(product.preco).toFixed(2)}`
                 : "Preço indisponível"}
@@ -133,27 +126,27 @@ export default function ProductCard({ product, priority = false }: Props) {
 
         {/* ABAIXO DA MÉDIA */}
         {product.isBelowAverage && product.priceDiffPercent != null && (
-          <div className="text-sm text-[#45C4B0] font-bold">
+          <div className="text-xs text-success font-semibold">
             ⬇ {Math.abs(product.priceDiffPercent).toFixed(1)}% abaixo da média
           </div>
         )}
 
         {/* BOTÕES */}
-        <div className="flex gap-3 mt-4">
+        <div className="flex gap-2 mt-3">
           <Link
             href={productUrl}
             className="
-          flex-1
-          bg-[#DAFDBA]
-          hover:bg-[#45C4B0]
-          text-[#000D34]
-          text-sm
-          font-semibold
-          py-2.5
-          rounded-xl
-          transition
-          text-center
-        "
+              flex-1
+              bg-panel-subtle
+              hover:bg-line
+              text-ink-muted hover:text-ink
+              text-sm
+              font-medium
+              py-2.5
+              rounded-xl
+              transition
+              text-center
+            "
           >
             Detalhes
           </Link>
@@ -164,29 +157,22 @@ export default function ProductCard({ product, priority = false }: Props) {
               target="_blank"
               rel="noopener noreferrer sponsored"
               className="
-            flex-1
-            bg-[#F5F138]
-            hover:brightness-95
-            text-[#000D34]
-            text-sm
-            font-bold
-            py-2.5
-            rounded-xl
-            transition
-            text-center
-          "
+                flex-1
+                bg-primary
+                hover:bg-primary-hover
+                text-white
+                text-sm
+                font-semibold
+                py-2.5
+                rounded-xl
+                transition
+                text-center
+              "
             >
               Comprar
             </a>
           )}
         </div>
-
-        {/* BADGE OPORTUNIDADE */}
-        {showOpportunity && (
-          <span className="absolute bottom-0 right-4 bg-[#45C4B0] text-[#000D34] text-xs font-extrabold px-3 py-1 rounded-full shadow-md">
-            🔥 Oportunidade
-          </span>
-        )}
       </div>
     </article>
   );

--- a/promoly-next/src/components/category/CategoryFilters.tsx
+++ b/promoly-next/src/components/category/CategoryFilters.tsx
@@ -24,8 +24,10 @@ export default function CategoryFilters() {
 
     router.push(`?${params.toString()}`);
   }
+
   return (
-    <div className="flex flex-col sm:flex-row gap-4 mb-12">
+    <div className="flex flex-col sm:flex-row gap-4 mb-10">
+
       {/* ================= BUSCA ================= */}
       <input
         type="text"
@@ -38,44 +40,45 @@ export default function CategoryFilters() {
           }
         }}
         className="
-        w-full sm:w-72
-        px-4 py-3
-        bg-[#0a154a]
-        border border-[#45C4B0]
-        rounded-xl
-        text-[#9AEBA3]
-        placeholder:text-[#45C4B0]
-        font-semibold
-        focus:outline-none
-        focus:ring-2
-        focus:ring-[#F5F138]
-        focus:border-[#F5F138]
-        transition
-      "
+          w-full sm:w-64
+          px-4 py-3
+          bg-panel
+          border border-line
+          rounded-xl
+          text-ink
+          placeholder:text-ink-faint
+          focus:outline-none
+          focus:ring-2
+          focus:ring-primary
+          focus:border-primary
+          transition
+        "
       />
 
       {/* ================= FILTRO ================= */}
       <select
         value={currentOrder}
-        onChange={(e) => updateParams({ order: e.target.value })}
+        onChange={(e) =>
+          updateParams({ order: e.target.value })
+        }
         className="
-        px-4 py-3
-        bg-[#0a154a]
-        border border-[#45C4B0]
-        rounded-xl
-        text-[#9AEBA3]
-        font-semibold
-        focus:outline-none
-        focus:ring-2
-        focus:ring-[#F5F138]
-        focus:border-[#F5F138]
-        transition
-      "
+          px-4 py-3
+          bg-panel
+          border border-line
+          rounded-xl
+          text-ink
+          focus:outline-none
+          focus:ring-2
+          focus:ring-primary
+          focus:border-primary
+          transition
+        "
       >
         <option value="desconto">Maior desconto</option>
         <option value="preco">Menor preço</option>
         <option value="recentes">Mais recentes</option>
       </select>
+
     </div>
   );
 }

--- a/promoly-next/src/components/layout/Footer.tsx
+++ b/promoly-next/src/components/layout/Footer.tsx
@@ -1,12 +1,14 @@
 import Link from "next/link";
-
 export default function Footer() {
   return (
-    <footer className="bg-gray-900 text-gray-300 mt-24">
+    <footer className="bg-panel border-t border-line text-ink-muted mt-24">
       <div className="max-w-7xl mx-auto px-6 py-12 grid md:grid-cols-3 gap-10">
         {/* SOBRE */}
         <div>
-          <h3 className="text-white text-lg font-semibold mb-4">PromoLy</h3>
+          <h3 className="text-lg font-extrabold mb-4">
+            <span className="text-primary">Promo</span>
+            <span className="text-success">ly</span>
+          </h3>
           <p className="text-sm leading-relaxed">
             Compare preços, acompanhe histórico real e descubra quando um
             produto está realmente abaixo da média.
@@ -15,17 +17,17 @@ export default function Footer() {
 
         {/* LINKS ÚTEIS */}
         <div>
-          <h3 className="text-white text-lg font-semibold mb-4">Links úteis</h3>
+          <h3 className="text-ink text-lg font-semibold mb-4">Links úteis</h3>
           <ul className="space-y-2 text-sm">
             <li>
-              <a href="/sitemap.xml" className="hover:text-white transition">
+              <a href="/sitemap.xml" className="hover:text-ink transition">
                 Sitemap
               </a>
             </li>
             <li>
               <Link
                 href="/categoria/eletronicos"
-                className="hover:text-white transition"
+                className="hover:text-ink transition"
               >
                 Eletrônicos
               </Link>
@@ -33,7 +35,7 @@ export default function Footer() {
             <li>
               <Link
                 href="/categoria/games"
-                className="hover:text-white transition"
+                className="hover:text-ink transition"
               >
                 Games
               </Link>
@@ -41,7 +43,7 @@ export default function Footer() {
             <li>
               <Link
                 href="/categoria/casa"
-                className="hover:text-white transition"
+                className="hover:text-ink transition"
               >
                 Casa
               </Link>
@@ -51,15 +53,13 @@ export default function Footer() {
 
         {/* REDES SOCIAIS */}
         <div>
-          <h3 className="text-white text-lg font-semibold mb-4">
-            Redes sociais
-          </h3>
+          <h3 className="text-ink text-lg font-semibold mb-4">Redes sociais</h3>
           <div className="flex flex-col gap-2 text-sm">
             <a
               href="https://instagram.com/Promoly__"
               target="_blank"
               rel="noopener noreferrer"
-              className="hover:text-white transition"
+              className="hover:text-ink transition"
             >
               Instagram
             </a>
@@ -68,7 +68,7 @@ export default function Footer() {
               href="https://twitter.com/Promoly_"
               target="_blank"
               rel="noopener noreferrer"
-              className="hover:text-white transition"
+              className="hover:text-ink transition"
             >
               Twitter
             </a>
@@ -78,7 +78,7 @@ export default function Footer() {
               https://www.facebook.com/PromolyCore"
               target="_blank"
               rel="noopener noreferrer"
-              className="hover:text-white transition"
+              className="hover:text-ink transition"
             >
               Facebook
             </a>
@@ -86,7 +86,7 @@ export default function Footer() {
         </div>
       </div>
 
-      <div className="border-t border-gray-700 py-6 text-center text-xs text-gray-400">
+      <div className="border-t border-line py-6 text-center text-xs text-ink-faint">
         © {new Date().getFullYear()} PromoLy. Todos os direitos reservados.
       </div>
     </footer>

--- a/promoly-next/src/components/layout/Header.tsx
+++ b/promoly-next/src/components/layout/Header.tsx
@@ -17,17 +17,15 @@ export default function Header() {
   );
 
   return (
-    <header className="bg-[#000D34] border-b border-[#0f1a4d] sticky top-0 z-50 shadow-soft">
+    <header className="bg-base/80 backdrop-blur-xl border-b border-line sticky top-0 z-50">
       <div className="max-w-7xl mx-auto px-4 h-16 flex items-center justify-between">
+        {/* LOGO */}
         <Link
           href="/"
-          className="flex items-center gap-2 text-2xl font-extrabold tracking-tight"
+          className="flex items-center text-2xl font-extrabold tracking-tight"
         >
-          <span className="text-[#9AEBA3]">Promo</span>
-          <span>
-            <span className="text-[#F5F138]">l</span>
-            <span className="text-[#9AEBA3]">y</span>
-          </span>
+          <span className="text-primary">Promo</span>
+          <span className="text-success">ly</span>
         </Link>
 
         {/* DESKTOP MENU */}
@@ -36,7 +34,7 @@ export default function Header() {
             <Link
               key={cat.slug}
               href={`/categoria/${cat.slug}`}
-              className="text-[#9AEBA3] hover:opacity-80 transition font-semibold"
+              className="text-ink-muted hover:text-ink transition font-medium"
             >
               {cat.label}
             </Link>
@@ -44,7 +42,7 @@ export default function Header() {
 
           {/* DROPDOWN */}
           <div className="relative group">
-            <button className="text-[#9AEBA3] hover:opacity-80 transition font-semibold">
+            <button className="text-ink-muted hover:text-ink transition font-medium">
               Mais ▾
             </button>
 
@@ -54,22 +52,22 @@ export default function Header() {
               className="
                 absolute left-0 top-full
                 w-52
-                bg-[#000D34]
-                border border-[#0f1a4d]
+                bg-panel-elevated
+                border border-line
                 rounded-xl
-                shadow-medium
+                shadow-elevated
                 p-4
                 hidden
                 group-hover:flex
                 flex-col
-                gap-2
+                gap-1
               "
             >
               {otherCategories.map((cat) => (
                 <Link
                   key={cat.slug}
                   href={`/categoria/${cat.slug}`}
-                  className="text-[#9AEBA3] hover:opacity-80 text-sm transition font-medium"
+                  className="text-ink-muted hover:text-ink hover:bg-panel-subtle rounded-lg px-3 py-2 text-sm transition font-medium"
                 >
                   {cat.label}
                 </Link>
@@ -80,37 +78,38 @@ export default function Header() {
 
         {/* MOBILE BUTTON */}
         <button
-          className="md:hidden text-[#9AEBA3] text-2xl"
+          className="md:hidden text-ink text-2xl"
+          aria-label="Abrir menu"
           onClick={() => setMobileOpen(!mobileOpen)}
         >
-          ☰
+          {mobileOpen ? "✕" : "☰"}
         </button>
       </div>
 
       {/* MOBILE MENU */}
       {mobileOpen && (
-        <div className="md:hidden bg-[#000D34] border-t border-[#0f1a4d] shadow-soft">
-          <div className="flex flex-col px-4 py-4 gap-4 text-sm">
+        <div className="md:hidden bg-panel border-t border-line">
+          <div className="flex flex-col px-4 py-4 gap-1 text-sm">
             {mainCategories.map((cat) => (
               <Link
                 key={cat.slug}
                 href={`/categoria/${cat.slug}`}
                 onClick={() => setMobileOpen(false)}
-                className="text-[#9AEBA3] font-medium hover:opacity-80 transition"
+                className="text-ink font-medium hover:bg-panel-subtle rounded-lg px-3 py-2.5 transition"
               >
                 {cat.label}
               </Link>
             ))}
 
             <button
-              className="text-left text-[#9AEBA3] font-semibold"
+              className="text-left text-ink-muted font-semibold px-3 py-2.5"
               onClick={() => setMoreOpen(!moreOpen)}
             >
-              Mais categorias
+              Mais categorias {moreOpen ? "▴" : "▾"}
             </button>
 
             {moreOpen && (
-              <div className="flex flex-col gap-2 pl-4 border-l border-[#1b2a66]">
+              <div className="flex flex-col gap-1 pl-4 border-l border-line ml-3">
                 {otherCategories.map((cat) => (
                   <Link
                     key={cat.slug}
@@ -119,7 +118,7 @@ export default function Header() {
                       setMobileOpen(false);
                       setMoreOpen(false);
                     }}
-                    className="text-[#9AEBA3] hover:opacity-80 transition"
+                    className="text-ink-muted hover:text-ink rounded-lg px-3 py-2 transition"
                   >
                     {cat.label}
                   </Link>

--- a/promoly-next/src/features/category_low_prices/CategoryLowPricesView.tsx
+++ b/promoly-next/src/features/category_low_prices/CategoryLowPricesView.tsx
@@ -28,30 +28,25 @@ export default function CategoryLowestPriceView({
   const today = new Date().toLocaleDateString("pt-BR");
 
   return (
-    <div className="bg-[#000D34] min-h-screen">
-      <div className="max-w-7xl mx-auto px-6 py-16">
-        {/* ================= HEADER ================= */}
-        <header className="mb-20 text-center">
-          <h1 className="text-3xl sm:text-4xl md:text-5xl font-extrabold text-[#9AEBA3] leading-tight mb-4">
-            🔥 Menor preço em{" "}
-            <span className="text-[#F5F138]">{categoriaNome}</span> hoje
+    <div className="bg-base min-h-screen">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 py-14">
+        <header className="mb-12 sm:mb-16">
+          <h1 className="text-3xl sm:text-4xl font-bold mb-4 text-ink">
+            🔥 Menor preço em {categoriaNome} hoje
           </h1>
-
-          <p className="text-[#45C4B0] text-lg font-semibold">
+          <p className="text-ink-muted">
             Produtos abaixo da média histórica. Atualizado em {today}
           </p>
         </header>
 
-        {/* ================= HERO ================= */}
+        {/* HERO vindo da page (igual à principal) */}
         <CategoryHeroHighlight product={heroProduct} />
 
-        {/* ================= GRID ================= */}
-        <div className="mt-20">
-          <CategoryLowestGrid products={enriched} />
-        </div>
+        {/* GRID usando enriched já tratado */}
+        <CategoryLowestGrid products={enriched} />
       </div>
 
-      {/* ================= SCHEMAS ================= */}
+      {/* SCHEMAS */}
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{

--- a/promoly-next/src/features/category_low_prices/components/CategoryLowestGrid/index.tsx
+++ b/promoly-next/src/features/category_low_prices/components/CategoryLowestGrid/index.tsx
@@ -8,7 +8,7 @@ type Props = {
 export default function CategoryLowestGrid({ products }: Props) {
   return (
     <section>
-      <h2 className="text-2xl font-bold mb-10">Todos abaixo da média</h2>
+      <h2 className="text-2xl font-bold mb-10 text-ink">Todos abaixo da média</h2>
 
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-8">
         {products.map((p) => (

--- a/promoly-next/src/features/low_prices/LowPricesView.tsx
+++ b/promoly-next/src/features/low_prices/LowPricesView.tsx
@@ -1,8 +1,10 @@
 import Highlight from "./components/HeroHighlight";
 import CategorySection from "./components/CategorySections";
 import FAQSection from "./components/FAQSection";
+
 import { buildLowestPriceSchemas } from "./utils/lowestPriceSchema";
 import type { EnrichedProduct } from "@/types";
+
 
 type Props = {
   enriched: EnrichedProduct[];
@@ -31,52 +33,48 @@ export default function LowPriceView({
   );
 
   return (
-    <div className="bg-[#000D34] min-h-screen">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 py-10 sm:py-16">
+    <div className="bg-base min-h-screen">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 py-8 sm:py-14">
         {/* ================= HEADER ================= */}
-        <header className="mb-20 text-center">
-          <h1 className="text-3xl sm:text-4xl md:text-5xl font-extrabold text-[#9AEBA3] leading-tight mb-4">
-            🔥 Radar de Oportunidades –{" "}
-            <span className="text-[#F5F138]">
-              Produtos abaixo da média histórica
-            </span>
+        <header className="mb-12 sm:mb-16">
+          <h1 className="text-2xl sm:text-3xl md:text-5xl font-bold leading-tight mb-3 text-ink">
+            🔥 Radar de Oportunidades – Produtos abaixo da média histórica
           </h1>
-
-          <p className="text-[#45C4B0] text-lg">Atualizado em {today}</p>
+          <p className="text-ink-muted text-lg">Atualizado em {today}</p>
         </header>
 
         {/* ================= HERO GLOBAL ================= */}
-        <section className="mb-24">
-          <div className="bg-[#0a154a] rounded-2xl border border-[#45C4B0] p-6 sm:p-10 shadow-lg">
-            <Highlight product={heroProduct} />
-          </div>
+        <section className="mb-16 sm:mb-20">
+          <Highlight product={heroProduct} />
         </section>
 
         {/* ================= EXPLICAÇÃO SEO ================= */}
-        <section className="max-w-3xl mx-auto mb-28">
-          <div className="bg-[#0a154a] rounded-2xl border border-[#45C4B0] p-8 sm:p-12 text-center shadow-lg">
+        <section className="max-w-3xl mx-auto mb-16 sm:mb-24">
+          <div className="bg-panel rounded-2xl shadow-elevated border border-line p-8 sm:p-10 text-center">
             <div className="flex items-center justify-center gap-3 mb-6">
-              <span className="text-2xl bg-[#45C4B0] text-[#000D34] rounded-lg px-3 py-1 font-bold">
-                💡
-              </span>
-
-              <h2 className="text-2xl md:text-3xl font-bold text-[#9AEBA3]">
+              <span className="text-2xl bg-primary/10 rounded-lg p-2">💡</span>
+              <h2 className="text-2xl md:text-3xl font-bold text-ink">
                 Como identificamos o menor preço?
               </h2>
             </div>
 
-            <p className="text-[#45C4B0] text-lg mb-4 font-bold">
+            <p className="text-ink-muted text-lg mb-4">
               Monitoramos automaticamente o histórico de{" "}
-              <span className="text-[#F5F138]">milhares de produtos</span>. Só
-              aparecem aqui quando estão{" "}
-              <span className="text-[#F5F138]">abaixo da média histórica</span>.
+              <span className="font-semibold text-primary">
+                milhares de produtos
+              </span>
+              . Só aparecem aqui quando estão{" "}
+              <span className="font-semibold text-success">
+                abaixo da média histórica
+              </span>
+              .
             </p>
 
-            <p className="text-[#45C4B0] mb-2 font-bold">
+            <p className="text-ink-muted mb-2">
               Aqui você vê quedas reais, não promoções artificiais.
             </p>
 
-            <p className="text-[#45C4B0] text-sm opacity-80 font-bold">
+            <p className="text-ink-faint text-sm">
               Atualização várias vezes ao dia para garantir oportunidades reais.
             </p>
           </div>

--- a/promoly-next/src/features/low_prices/components/CategorySections/CategoryProductActions.tsx
+++ b/promoly-next/src/features/low_prices/components/CategorySections/CategoryProductActions.tsx
@@ -6,26 +6,24 @@ type Props = {
 
 export default function CategoryProductActions({ product }: Props) {
   return (
-    <div className="flex flex-col sm:flex-row gap-4 mt-10">
-      {/* DETALHES */}
+    <div className="flex gap-4 mt-8">
       <a
         href={`/produto/${product.slug}-${product.produto_id}`}
         className="
           flex-1
-          bg-[#DAFDBA]
-          hover:bg-[#45C4B0]
-          text-[#000D34]
-          font-semibold
+          bg-panel-subtle
+          hover:bg-line
+          text-ink-muted hover:text-ink
+          border border-line
           py-3
           rounded-xl
           text-center
           transition
         "
       >
-        Ver detalhes
+        Detalhes
       </a>
 
-      {/* COMPRAR */}
       {product.url_afiliada && (
         <a
           href={product.url_afiliada}
@@ -33,17 +31,16 @@ export default function CategoryProductActions({ product }: Props) {
           rel="noopener noreferrer sponsored"
           className="
             flex-1
-            bg-[#F5F138]
-            hover:brightness-95
-            text-[#000D34]
-            font-bold
+            bg-primary
+            hover:bg-primary-hover
+            text-white
             py-3
             rounded-xl
             text-center
             transition
           "
         >
-          Comprar agora
+          Comprar
         </a>
       )}
     </div>

--- a/promoly-next/src/features/low_prices/components/CategorySections/CategoryProductMetrics.tsx
+++ b/promoly-next/src/features/low_prices/components/CategorySections/CategoryProductMetrics.tsx
@@ -5,80 +5,74 @@ type Props = {
 };
 
 export default function CategoryProductMetrics({ product }: Props) {
-  const formatCurrency = (value: number) =>
-    value.toLocaleString("pt-BR", {
-      style: "currency",
-      currency: "BRL",
-    });
-
   return (
     <>
-      {/* TÍTULO */}
-      <h3 className="text-xl font-semibold text-[#9AEBA3] mb-4 leading-snug">
-        {product.titulo}
-      </h3>
+      <h3 className="text-lg font-semibold mb-3 text-ink">{product.titulo}</h3>
 
-      {/* PREÇO ATUAL */}
-      <p className="text-4xl font-extrabold text-[#F5F138] mb-8">
-        {formatCurrency(product.currentPrice)}
+      <p className="text-3xl font-extrabold text-success mb-6">
+        {product.currentPrice.toLocaleString("pt-BR", {
+          style: "currency",
+          currency: "BRL",
+        })}
       </p>
 
-      {/* MÉTRICAS */}
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-6 mb-8">
+      <div className="grid grid-cols-2 gap-6 mb-6">
         {/* MÉDIA HISTÓRICA */}
-        <div className="bg-[#0a154a] border border-[#45C4B0] rounded-xl p-5">
-          <p className="text-xs text-[#45C4B0] uppercase mb-2 tracking-wide">
-            Média histórica
+        <div>
+          <p className="text-xs text-ink-faint uppercase mb-1">Média histórica</p>
+          <p className="font-semibold text-lg text-ink">
+            {product.avgPrice.toLocaleString("pt-BR", {
+              style: "currency",
+              currency: "BRL",
+            })}
           </p>
-
-          <p className="font-semibold text-lg text-[#9AEBA3]">
-            {formatCurrency(product.avgPrice)}
-          </p>
-
-          <p
-            className={`font-bold text-base ${
-              product.priceDiffPercent > 0 ? "text-red-400" : "text-[#F5F138]"
-            }`}
-          >
-            {product.priceDiffPercent > 0 ? "+" : ""}
+          <p className="text-success font-bold">
             {product.priceDiffPercent.toFixed(1)}% (
-            {formatCurrency(product.currentPrice - product.avgPrice)})
+            {(product.currentPrice - product.avgPrice).toLocaleString("pt-BR", {
+              style: "currency",
+              currency: "BRL",
+            })}
+            )
           </p>
         </div>
 
         {/* ÚLTIMO PREÇO */}
         {product.lastPrice !== null && (
-          <div className="bg-[#0a154a] border border-[#45C4B0] rounded-xl p-5">
-            <p className="text-xs text-[#45C4B0] uppercase mb-2 tracking-wide">
-              Último preço
+          <div>
+            <p className="text-xs text-ink-faint uppercase mb-1">Último preço</p>
+            <p className="font-semibold text-lg text-ink">
+              {product.lastPrice.toLocaleString("pt-BR", {
+                style: "currency",
+                currency: "BRL",
+              })}
             </p>
-
-            <p className="font-semibold text-lg text-[#9AEBA3]">
-              {formatCurrency(product.lastPrice)}
-            </p>
-
             <p
-              className={`font-bold text-base ${
-                product.variationVsLast > 0 ? "text-red-400" : "text-[#F5F138]"
+              className={`font-bold ${
+                product.variationVsLast > 0 ? "text-danger" : "text-success"
               }`}
             >
               {product.variationVsLast > 0 ? "+" : ""}
               {product.variationVsLast.toFixed(1)}% (
-              {formatCurrency(product.currentPrice - product.lastPrice)})
+              {(product.currentPrice - product.lastPrice).toLocaleString(
+                "pt-BR",
+                {
+                  style: "currency",
+                  currency: "BRL",
+                },
+              )}
+              )
             </p>
           </div>
         )}
       </div>
 
       {/* HISTÓRICO TEXTO */}
-      <h4 className="text-lg font-bold text-[#9AEBA3] mb-3">
-        Histórico de preço
-      </h4>
+      <h4 className="text-base font-bold mb-2 text-ink">Histórico de preço</h4>
 
       {product.variationVsLast !== null && (
         <p
-          className={`text-base font-semibold ${
-            product.variationVsLast > 0 ? "text-red-400" : "text-[#F5F138]"
+          className={`text-sm mb-6 font-medium ${
+            product.variationVsLast > 0 ? "text-danger" : "text-success"
           }`}
         >
           {product.variationVsLast > 0 ? "⬆" : "⬇"}{" "}

--- a/promoly-next/src/features/low_prices/components/CategorySections/CategoryTopProduct.tsx
+++ b/promoly-next/src/features/low_prices/components/CategorySections/CategoryTopProduct.tsx
@@ -10,40 +10,23 @@ type Props = {
 
 export default function CategoryTopProduct({ product }: Props) {
   return (
-    <div className="bg-[#0a154a] border border-[#45C4B0] rounded-2xl p-8 sm:p-10 shadow-lg mb-16">
-      {/* BLOCO SUPERIOR */}
-      <div className="grid md:grid-cols-2 gap-12 items-start mb-14">
-        {/* IMAGEM */}
-        <div className="flex justify-center">
+    <div className="bg-panel rounded-2xl p-4 sm:p-6 shadow-elevated border border-line mb-10">
+      <div className="grid md:grid-cols-2 gap-8 md:gap-10">
+        <div className="bg-white rounded-xl p-6 flex items-center justify-center">
           <Image
             src={product.imagem_url ?? "/placeholder.png"}
             alt={product.titulo}
             width={500}
             height={500}
-            className="
-      w-full
-      max-w-[416px]      /* 30% maior no mobile */
-      sm:max-w-[420px]   /* desktop mantém */
-      h-auto
-      rounded-xl
-      object-contain
-      transition-transform
-      duration-300
-      hover:scale-105
-    "
+            className="w-full rounded-xl object-contain"
           />
         </div>
 
-        {/* MÉTRICAS + AÇÕES */}
         <div>
           <CategoryProductMetrics product={product} />
+          <CategoryProductChart product={product} />
           <CategoryProductActions product={product} />
         </div>
-      </div>
-
-      {/* GRÁFICO FULL WIDTH */}
-      <div className="mt-6">
-        <CategoryProductChart product={product} />
       </div>
     </div>
   );

--- a/promoly-next/src/features/low_prices/components/FAQSection/FAQCard.tsx
+++ b/promoly-next/src/features/low_prices/components/FAQSection/FAQCard.tsx
@@ -7,14 +7,14 @@ type Props = {
 
 export default function FAQCard({ icon, iconBg, title, content }: Props) {
   return (
-    <div className="bg-white rounded-2xl p-8 md:p-10 shadow-soft border border-gray-100 hover:shadow-medium hover:-translate-y-1 transition-all duration-300 group">
+    <div className="bg-panel rounded-2xl p-6 md:p-8 shadow-elevated border border-line hover:border-primary/40 hover:-translate-y-1 transition-all duration-300 group">
       <div className="flex items-start gap-4 mb-5">
         <div className={`${iconBg} rounded-xl p-3 flex-shrink-0 group-hover:scale-110 transition-transform`}>
           <span className="text-2xl">{icon}</span>
         </div>
-        <h3 className="text-lg md:text-xl font-bold text-gray-900 leading-tight">{title}</h3>
+        <h3 className="text-lg md:text-xl font-bold text-ink leading-tight">{title}</h3>
       </div>
-      <p className="text-gray-600 leading-relaxed text-base">{content}</p>
+      <p className="text-ink-muted leading-relaxed text-base [&_strong]:text-ink">{content}</p>
     </div>
   );
 }

--- a/promoly-next/src/features/low_prices/components/FAQSection/FAQHeader.tsx
+++ b/promoly-next/src/features/low_prices/components/FAQSection/FAQHeader.tsx
@@ -4,10 +4,10 @@ export default function FAQHeader() {
       <div className="bg-primary/5 rounded-full p-4 mb-6">
         <span className="text-4xl">❓</span>
       </div>
-      <h2 className="text-4xl md:text-5xl font-bold mb-4 max-w-2xl">
+      <h2 className="text-3xl md:text-5xl font-bold mb-4 max-w-2xl text-ink">
         Dúvidas sobre o Radar de Oportunidades?
       </h2>
-      <p className="text-gray-600 text-lg max-w-2xl leading-relaxed">
+      <p className="text-ink-muted text-lg max-w-2xl leading-relaxed">
         Aqui você encontra respostas sobre como funcionam nossas análises de preço e como identificamos as melhores oportunidades para você economizar.
       </p>
     </div>

--- a/promoly-next/src/features/low_prices/components/HeroHighlight/HeroActions.tsx
+++ b/promoly-next/src/features/low_prices/components/HeroHighlight/HeroActions.tsx
@@ -6,26 +6,24 @@ type Props = {
 
 export default function HeroActions({ product }: Props) {
   return (
-    <div className="flex flex-col sm:flex-row gap-4 mt-10">
-      {/* DETALHES */}
+    <div className="flex gap-4 mt-8 justify-start">
       <a
         href={`/produto/${product.slug}-${product.produto_id}`}
         className="
           flex-1
-          bg-[#DAFDBA]
-          hover:bg-[#45C4B0]
-          text-[#000D34]
-          font-semibold
+          bg-panel-subtle
+          hover:bg-line
+          text-ink-muted hover:text-ink
+          border border-line
           py-3
           rounded-xl
           text-center
           transition
         "
       >
-        Ver detalhes
+        Detalhes
       </a>
 
-      {/* COMPRAR */}
       {product.url_afiliada && (
         <a
           href={product.url_afiliada}
@@ -33,17 +31,16 @@ export default function HeroActions({ product }: Props) {
           rel="noopener noreferrer sponsored"
           className="
             flex-1
-            bg-[#F5F138]
-            hover:brightness-95
-            text-[#000D34]
-            font-bold
+            bg-primary
+            hover:bg-primary-hover
+            text-white
             py-3
             rounded-xl
             text-center
             transition
           "
         >
-          Comprar agora
+          Comprar
         </a>
       )}
     </div>

--- a/promoly-next/src/features/low_prices/components/HeroHighlight/HeroImage.tsx
+++ b/promoly-next/src/features/low_prices/components/HeroHighlight/HeroImage.tsx
@@ -7,44 +7,20 @@ type Props = {
 
 export default function HeroImage({ product }: Props) {
   return (
-    <div className="w-full flex justify-center">
-      <div
-        className="
-  bg-[#0a154a]
-  border border-[#45C4B0]
-  rounded-2xl
-  p-6 sm:p-8
-  shadow-lg
-  flex
-  justify-center
-  items-center
-"
-      >
-        <Image
-          src={product.imagem_url ?? "/placeholder.png"}
-          alt={product.titulo}
-          width={600}
-          height={600}
-          priority
-          className="
-      w-full
-      max-w-[390px]      /* 30% maior no mobile */
-      sm:max-w-[380px]
-      md:max-w-[480px]
-      h-auto
-      object-contain
-      rounded-xl
-      transition-transform
-      duration-300
-      hover:scale-105
-    "
-          sizes="
-      (max-width: 640px) 390px,
-      (max-width: 1024px) 380px,
-      480px
-    "
-        />
-      </div>
+    <div className="w-full flex justify-center bg-white rounded-2xl p-6">
+      <Image
+        src={product.imagem_url ?? "/placeholder.png"}
+        alt={product.titulo}
+        width={600}
+        height={600}
+        priority
+        className="w-full max-w-[260px] sm:max-w-[340px] md:max-w-[420px] h-auto object-contain rounded-xl"
+        sizes="
+          (max-width: 640px) 260px,
+          (max-width: 1024px) 340px,
+          420px
+        "
+      />
     </div>
   );
 }

--- a/promoly-next/src/features/low_prices/components/HeroHighlight/HeroMetrics.tsx
+++ b/promoly-next/src/features/low_prices/components/HeroHighlight/HeroMetrics.tsx
@@ -7,6 +7,7 @@ type Props = {
 export default function HeroMetrics({ product }: Props) {
   if (!product) return null;
 
+  // 🔹 Mapear campos do backend (português → padrão interno)
   const currentPrice =
     "preco_atual" in product && typeof product.preco_atual === "number"
       ? product.preco_atual
@@ -17,6 +18,7 @@ export default function HeroMetrics({ product }: Props) {
       ? product.preco_anterior
       : (product.previousPrice ?? null);
 
+  // 🔹 Média histórica (fallback)
   const avgPrice =
     typeof product.avgPrice === "number"
       ? product.avgPrice
@@ -25,9 +27,11 @@ export default function HeroMetrics({ product }: Props) {
   const lastPrice =
     typeof product.lastPrice === "number" ? product.lastPrice : null;
 
+  // 🔹 Diferença vs média
   const priceDiffPercent =
     avgPrice > 0 ? ((currentPrice - avgPrice) / avgPrice) * 100 : 0;
 
+  // 🔹 Variação vs último preço
   const variationVsLast =
     lastPrice && lastPrice > 0
       ? ((currentPrice - lastPrice) / lastPrice) * 100
@@ -41,30 +45,29 @@ export default function HeroMetrics({ product }: Props) {
 
   return (
     <>
-      {/* TÍTULO */}
-      <h3 className="text-lg sm:text-xl font-semibold text-[#9AEBA3] mb-3 leading-snug">
+      <h3 className="text-base sm:text-lg font-semibold mb-2 leading-snug text-ink">
         {product.titulo}
       </h3>
 
       {/* PREÇO ATUAL */}
-      <p className="text-3xl sm:text-5xl font-extrabold text-[#F5F138] mb-8">
+      <p className="text-2xl sm:text-4xl font-extrabold text-success mb-4 sm:mb-8">
         {formatCurrency(currentPrice)}
       </p>
 
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-6 mb-10">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 sm:gap-8 mb-6 sm:mb-10">
         {/* MÉDIA HISTÓRICA */}
-        <div className="bg-[#0a154a] border border-[#45C4B0] rounded-xl p-5">
-          <p className="text-xs text-[#45C4B0] uppercase mb-2 tracking-wide">
+        <div className="bg-panel-subtle border border-line rounded-lg p-3 sm:p-4">
+          <p className="text-[10px] sm:text-xs text-ink-faint uppercase mb-1">
             Média histórica
           </p>
 
-          <p className="font-semibold text-lg text-[#9AEBA3]">
+          <p className="font-semibold text-base sm:text-lg text-ink">
             {formatCurrency(avgPrice)}
           </p>
 
           <p
-            className={`font-bold text-base ${
-              priceDiffPercent > 0 ? "text-red-400" : "text-[#F5F138]"
+            className={`font-bold text-sm sm:text-base ${
+              priceDiffPercent > 0 ? "text-danger" : "text-success"
             }`}
           >
             {priceDiffPercent > 0 ? "+" : ""}
@@ -75,18 +78,18 @@ export default function HeroMetrics({ product }: Props) {
 
         {/* ÚLTIMO PREÇO */}
         {lastPrice && (
-          <div className="bg-[#0a154a] border border-[#45C4B0] rounded-xl p-5">
-            <p className="text-xs text-[#45C4B0] uppercase mb-2 tracking-wide">
+          <div className="bg-panel-subtle border border-line rounded-lg p-3 sm:p-4">
+            <p className="text-[10px] sm:text-xs text-ink-faint uppercase mb-1">
               Último preço
             </p>
 
-            <p className="font-semibold text-lg text-[#9AEBA3]">
+            <p className="font-semibold text-base sm:text-lg text-ink">
               {formatCurrency(lastPrice)}
             </p>
 
             <p
-              className={`font-bold text-base ${
-                variationVsLast > 0 ? "text-red-400" : "text-[#F5F138]"
+              className={`font-bold text-sm sm:text-base ${
+                variationVsLast > 0 ? "text-danger" : "text-success"
               }`}
             >
               {variationVsLast > 0 ? "+" : ""}

--- a/promoly-next/src/features/low_prices/components/HeroHighlight/index.tsx
+++ b/promoly-next/src/features/low_prices/components/HeroHighlight/index.tsx
@@ -10,42 +10,19 @@ type Props = {
 
 export default function HeroHighlight({ product }: Props) {
   return (
-    <section
-      className="
-        bg-[#0a154a]
-        rounded-2xl
-        p-4 sm:p-8 lg:p-12
-        border border-[#45C4B0]
-        shadow-lg
-        mb-16 sm:mb-20
-      "
-    >
-      <h2 className="text-xl sm:text-2xl lg:text-3xl font-bold text-[#9AEBA3] mb-6 sm:mb-10 flex items-center gap-3">
-        <span className="text-[#F5F138] text-2xl sm:text-3xl">🏆</span>
-        Maior Queda do Dia
+    <section className="bg-panel rounded-2xl p-4 sm:p-10 shadow-elevated border border-line">
+      <h2 className="text-2xl font-bold mb-8 flex items-center gap-2 text-ink">
+        🏆 Maior Queda do Dia
       </h2>
 
-      {/* BLOCO SUPERIOR */}
-      <div
-        className="
-    flex flex-col
-    gap-6
-    lg:grid lg:grid-cols-2
-    lg:gap-12
-    items-center lg:items-start
-    mb-8 sm:mb-12 lg:mb-16
-  "
-      >
+      <div className="grid md:grid-cols-2 gap-8 md:gap-12">
         <HeroImage product={product} />
-        <div className="flex flex-col gap-6">
+
+        <div>
           <HeroMetrics product={product} />
+          <HeroChart product={product} />
           <HeroActions product={product} />
         </div>
-      </div>
-
-      {/* GRÁFICO FULL WIDTH */}
-      <div className="mt-6 sm:mt-8">
-        <HeroChart product={product} />
       </div>
     </section>
   );

--- a/promoly-next/src/features/product/components/ProductCardSkeleton.tsx
+++ b/promoly-next/src/features/product/components/ProductCardSkeleton.tsx
@@ -1,21 +1,21 @@
 export default function ProductCardSkeleton() {
   return (
     <div className="
-      bg-surface
+      bg-panel
       rounded-xl2
       p-5
-      border border-gray-200
-      shadow-soft
+      border border-line
+      shadow-elevated
       animate-pulse
     ">
-      <div className="h-36 bg-gray-200 rounded-xl mb-5" />
+      <div className="h-36 bg-panel-subtle rounded-xl mb-5" />
 
-      <div className="h-4 bg-gray-200 rounded w-3/4 mb-3" />
-      <div className="h-4 bg-gray-200 rounded w-1/2 mb-6" />
+      <div className="h-4 bg-panel-subtle rounded w-3/4 mb-3" />
+      <div className="h-4 bg-panel-subtle rounded w-1/2 mb-6" />
 
       <div className="flex gap-3">
-        <div className="h-9 bg-gray-200 rounded-xl flex-1" />
-        <div className="h-9 bg-gray-200 rounded-xl flex-1" />
+        <div className="h-9 bg-panel-subtle rounded-xl flex-1" />
+        <div className="h-9 bg-panel-subtle rounded-xl flex-1" />
       </div>
     </div>
   );

--- a/promoly-next/src/features/product/components/ProductDetails.tsx
+++ b/promoly-next/src/features/product/components/ProductDetails.tsx
@@ -15,36 +15,27 @@ export default function ProductDetails({ product }: Props) {
   };
 
   return (
-    <div className="flex flex-col md:grid md:grid-cols-2 gap-8 md:gap-10 items-start">
-      {/* ================= IMAGEM ================= */}
-      <div className="bg-[#000D34] border border-[#45C4B0] rounded-3xl p-3 sm:p-6 md:p-8 flex items-center justify-center w-full">
+    <div className="grid md:grid-cols-2 gap-8 items-start">
+      {/* IMAGEM */}
+      <div className="bg-white rounded-3xl p-6 flex items-center justify-center">
         <Image
           src={product.imagem_url ?? "/placeholder.png"}
           alt={`Imagem do produto ${product.titulo}`}
-          width={1500}
-          height={1600}
+          width={1200}
+          height={1200}
           priority
-          className="
-      object-contain
-      w-full
-      h-auto
-      max-h-none        /* MOBILE sem limite */
-      md:max-h-[420px]  /* Desktop mantém */
-      transition-transform
-      duration-300
-      hover:scale-105
-    "
+          className="object-contain w-full h-auto max-h-[420px]"
         />
       </div>
 
-      {/* ================= INFORMAÇÕES ================= */}
-      <div className="flex flex-col gap-5 w-full">
-        <h1 className="text-xl sm:text-2xl md:text-3xl font-extrabold text-[#9AEBA3] leading-snug">
+      {/* INFORMAÇÕES */}
+      <div className="flex flex-col gap-4">
+        <h1 className="text-2xl font-bold text-ink leading-snug">
           {product.titulo}
         </h1>
 
         {product.preco !== null && (
-          <div className="text-3xl sm:text-4xl md:text-4xl font-extrabold text-[#F5F138]">
+          <div className="text-3xl font-extrabold text-success">
             {product.preco.toLocaleString("pt-BR", {
               style: "currency",
               currency: "BRL",
@@ -53,29 +44,26 @@ export default function ProductDetails({ product }: Props) {
         )}
 
         {product.descricao && (
-          <p className="text-[#45C4B0] text-sm leading-relaxed">
+          <p className="text-ink-muted text-sm leading-relaxed">
             {product.descricao}
           </p>
         )}
 
-        {/* ================= BOTÕES ================= */}
-        <div className="flex flex-col sm:flex-row gap-3 mt-4 w-full">
+        <div className="flex gap-3 mt-4 flex-wrap">
           {product.url_afiliada && (
             <a
               href={product.url_afiliada}
               target="_blank"
               rel="noopener noreferrer sponsored"
               className="
-                w-full
-                bg-[#F5F138]
-                hover:brightness-95
-                text-[#000D34]
-                font-bold
-                py-3
-                rounded-xl
+                bg-primary
+                hover:bg-primary-hover
+                text-white
+                font-semibold
+                px-6
+                py-2.5
+                rounded-xl2
                 transition
-                shadow-lg
-                text-center
               "
             >
               Comprar pelo menor preço
@@ -85,14 +73,14 @@ export default function ProductDetails({ product }: Props) {
           <button
             onClick={handleCopyLink}
             className="
-              w-full
-              bg-[#DAFDBA]
-              hover:bg-[#45C4B0]
-              text-[#000D34]
-              font-semibold
-              py-3
-              rounded-xl
+              bg-panel-subtle
+              text-ink-muted
+              hover:text-ink hover:bg-line
+              px-5
+              py-2.5
+              rounded-xl2
               transition
+              border border-line
             "
           >
             Copiar link

--- a/promoly-next/src/features/product/components/ProductHistory.tsx
+++ b/promoly-next/src/features/product/components/ProductHistory.tsx
@@ -39,31 +39,40 @@ export default function ProductHistory({
 
   if (previousPrice && lastPrice) {
     variationPercent = ((lastPrice - previousPrice) / previousPrice) * 100;
+
     variationValue = lastPrice - previousPrice;
 
     if (variationPercent > 0.2) trend = "alta";
     else if (variationPercent < -0.2) trend = "queda";
   }
 
-  const trendTextColor =
+  const trendColor =
     trend === "queda"
-      ? "text-[#F5F138]"
+      ? "text-success"
       : trend === "alta"
-        ? "text-red-400"
-        : "text-[#45C4B0]";
+        ? "text-danger"
+        : "text-ink-muted";
+
+  const chartColor =
+    trend === "queda" ? "#22c55e" : trend === "alta" ? "#ef4444" : "#94a3b8";
+
+  const gradientId = `priceGradient-${trend}`;
 
   return (
     <motion.div
-      className="mt-10 sm:mt-16"
+      className="mt-8 sm:mt-16"
       initial={{ opacity: 0, y: 30 }}
       whileInView={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.6, ease: "easeOut" }}
       viewport={{ once: true }}
     >
-      <h2 className="text-xl sm:text-3xl font-bold text-[#9AEBA3] mb-3">
+      <h2 className="text-lg sm:text-2xl font-bold text-ink mb-2 sm:mb-4">
         Histórico de preço
       </h2>
-      <p className={`text-sm sm:text-lg font-semibold mb-6 ${trendTextColor}`}>
+
+      <p
+        className={`text-sm sm:text-lg font-semibold mb-4 sm:mb-6 ${trendColor}`}
+      >
         {trend === "queda" && "⬇ "}
         {trend === "alta" && "⬆ "}
         {trend === "estabilidade" && "➖ "}
@@ -79,15 +88,19 @@ export default function ProductHistory({
            },
          )}) vs último registro`}
       </p>
-      <div className="bg-[#0b154a] border border-[#45C4B0] rounded-2xl p-3 sm:p-6 lg:p-8 shadow-lg">
-        <div className="w-full h-64 sm:h-80 lg:h-96 xl:h-[440px]">
+
+      <div className="bg-panel-subtle border border-line rounded-2xl p-3 sm:p-6 lg:p-8">
+        <div className="w-full h-48 sm:h-64 lg:h-80 xl:h-[420px]">
           <ResponsiveContainer width="100%" height="100%">
             <LineChart data={data}>
-              <CartesianGrid
-                strokeDasharray="3 3"
-                stroke="#45C4B0"
-                opacity={0.12}
-              />
+              <defs>
+                <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="0%" stopColor={chartColor} stopOpacity={0.35} />
+                  <stop offset="100%" stopColor={chartColor} stopOpacity={0} />
+                </linearGradient>
+              </defs>
+
+              <CartesianGrid strokeDasharray="3 3" stroke="#1f2a3d" vertical={false} />
 
               <XAxis
                 dataKey="data"
@@ -97,17 +110,13 @@ export default function ProductHistory({
                     month: "2-digit",
                   })
                 }
-                tick={{
-                  fill: "#45C4B0",
-                  fontSize: 11, // menor no mobile
-                  fontWeight: 600,
-                }}
-                minTickGap={15}
-                stroke="#45C4B0"
+                tick={{ fontSize: 10, fill: "#94a3b8" }}
+                axisLine={{ stroke: "#1f2a3d" }}
+                tickLine={false}
+                minTickGap={25}
               />
-
               <YAxis
-                width={70} // menos espaço lateral
+                width={80}
                 domain={[lowerDomain, upperDomain]}
                 tickFormatter={(value: number) =>
                   value.toLocaleString("pt-BR", {
@@ -116,22 +125,22 @@ export default function ProductHistory({
                     maximumFractionDigits: 0,
                   })
                 }
-                tick={{
-                  fill: "#45C4B0",
-                  fontSize: 11,
-                  fontWeight: 600,
-                }}
-                stroke="#45C4B0"
+                tick={{ fontSize: 12, fill: "#94a3b8" }}
+                axisLine={false}
+                tickLine={false}
               />
 
               <Tooltip
+                cursor={{ stroke: chartColor, strokeWidth: 1, strokeDasharray: "4 4" }}
                 contentStyle={{
-                  backgroundColor: "#000D34",
-                  border: "1px solid #45C4B0",
-                  borderRadius: "12px",
-                  color: "#9AEBA3",
-                  fontSize: "12px", // menor no mobile
+                  background: "#161d2e",
+                  border: "1px solid #1f2a3d",
+                  borderRadius: "0.75rem",
+                  color: "#f1f5f9",
+                  boxShadow: "0 10px 40px rgba(0,0,0,0.45)",
                 }}
+                labelStyle={{ color: "#94a3b8", marginBottom: 4 }}
+                itemStyle={{ color: "#f1f5f9" }}
                 formatter={(value: number | undefined) =>
                   value != null
                     ? value.toLocaleString("pt-BR", {
@@ -143,6 +152,7 @@ export default function ProductHistory({
                 labelFormatter={(label) => {
                   const date =
                     typeof label === "number" ? label : Number(label);
+
                   if (isNaN(date)) return "";
                   return new Date(date).toLocaleDateString("pt-BR");
                 }}
@@ -152,32 +162,21 @@ export default function ProductHistory({
                 type="stepAfter"
                 dataKey="preco"
                 stroke="none"
-                fill="#F5F138"
-                fillOpacity={0.06}
+                fill={`url(#${gradientId})`}
               />
 
               <Line
                 type="stepAfter"
                 dataKey="preco"
-                stroke="#F5F138"
+                stroke={chartColor}
                 strokeWidth={2.5}
-                dot={{
-                  r: 3.5, // tamanho base visível
-                  fill: "#F5F138",
-                  stroke: "#000D34", // cria contraste
-                  strokeWidth: 1.5,
-                }}
-                activeDot={{
-                  r: 6,
-                  fill: "#F5F138",
-                  stroke: "#000D34",
-                  strokeWidth: 2,
-                }}
+                dot={false}
+                activeDot={{ r: 5, strokeWidth: 0 }}
               />
             </LineChart>
           </ResponsiveContainer>
         </div>
-      </div>{" "}
+      </div>
     </motion.div>
   );
 }

--- a/promoly-next/src/features/product/components/ProductPriceAnalysis.tsx
+++ b/promoly-next/src/features/product/components/ProductPriceAnalysis.tsx
@@ -35,34 +35,31 @@ export default function ProductPriceAnalysis({ analytics, decision }: Props) {
   const diff = metrics.priceDiffPercent;
 
   return (
-    <div className="bg-[#0a154a] rounded-3xl border border-[#45C4B0] p-10 shadow-lg">
-      <h2 className="text-2xl font-extrabold mb-6 text-[#9AEBA3]">
+    <div>
+      <h2 className="text-lg sm:text-2xl font-bold mb-4 sm:mb-6 text-ink">
         💡 Análise inteligente de preço
       </h2>
 
-      <p className="text-4xl font-extrabold text-[#F5F138] mb-8">
+      <p className="text-3xl sm:text-4xl font-extrabold text-ink mb-6">
         {metrics.currentPrice.toLocaleString("pt-BR", {
           style: "currency",
           currency: "BRL",
         })}
       </p>
 
-      <div className="grid sm:grid-cols-2 gap-8 mb-10">
+      <div className="grid sm:grid-cols-2 gap-4 sm:gap-6 mb-6 sm:mb-8">
         {/* MÉDIA HISTÓRICA */}
-        <div className="bg-[#000D34] rounded-2xl p-6 border border-[#45C4B0]">
-          <p className="text-xs uppercase text-[#45C4B0] mb-2 font-semibold">
+        <div className="bg-panel-subtle rounded-2xl p-5 sm:p-6 border border-line">
+          <p className="text-xs uppercase tracking-wide text-ink-faint mb-2">
             Média histórica
           </p>
-
-          <p className="font-bold text-lg text-[#9AEBA3]">
+          <p className="font-semibold text-lg text-ink">
             {metrics.avgPrice.toLocaleString("pt-BR", {
               style: "currency",
               currency: "BRL",
             })}
           </p>
-
-          <p className="text-[#45C4B0] font-bold mt-2">
-            {diff > 0 ? "+" : ""}
+          <p className="text-success font-bold mt-2">
             {diff.toFixed(1)}% (
             {diffVsAverageValue.toLocaleString("pt-BR", {
               style: "currency",
@@ -74,23 +71,19 @@ export default function ProductPriceAnalysis({ analytics, decision }: Props) {
 
         {/* ÚLTIMO PREÇO */}
         {lastPrice && (
-          <div className="bg-[#000D34] rounded-2xl p-6 border border-[#45C4B0]">
-            <p className="text-xs uppercase text-[#45C4B0] mb-2 font-semibold">
+          <div className="bg-panel-subtle rounded-2xl p-5 sm:p-6 border border-line">
+            <p className="text-xs uppercase tracking-wide text-ink-faint mb-2">
               Último preço registrado
             </p>
-
-            <p className="font-bold text-lg text-[#9AEBA3]">
+            <p className="font-semibold text-lg text-ink">
               {lastPrice.toLocaleString("pt-BR", {
                 style: "currency",
                 currency: "BRL",
               })}
             </p>
-
             <p
               className={`font-bold mt-2 ${
-                variationVsLast > 0
-                  ? "text-[#F87171]" // vermelho suave
-                  : "text-[#45C4B0]"
+                variationVsLast > 0 ? "text-danger" : "text-success"
               }`}
             >
               {variationVsLast > 0 ? "+" : ""}
@@ -105,25 +98,22 @@ export default function ProductPriceAnalysis({ analytics, decision }: Props) {
         )}
       </div>
 
-      {/* BLOCO DECISÃO */}
-      <div className="rounded-2xl p-6 border border-[#45C4B0] bg-[#000D34]">
-        <p className="text-lg font-extrabold text-[#F5F138]">
+      <div className={`rounded-2xl p-5 sm:p-6 border ${decision.bg}`}>
+        <p className={`text-lg font-bold ${decision.color}`}>
           {decision.icon} {decision.title}
         </p>
 
-        <p className="text-sm mt-3 text-[#45C4B0] font-semibold">
-          {decision.description}
-        </p>
+        <p className="text-sm mt-3 text-ink-muted">{decision.description}</p>
 
         {variationVsLast > 0 && diff < 0 && (
-          <p className="text-sm mt-3 font-semibold text-[#9AEBA3]">
+          <p className="text-sm mt-3 font-medium text-ink">
             📈 O preço subiu recentemente, mas ainda permanece abaixo da média
             histórica.
           </p>
         )}
 
         {isLowestEver && (
-          <p className="text-sm mt-3 font-bold text-[#45C4B0]">
+          <p className="text-sm mt-3 font-semibold text-success">
             🎯 Este é o menor preço já registrado para este produto.
           </p>
         )}

--- a/promoly-next/src/features/product/components/ProductView.tsx
+++ b/promoly-next/src/features/product/components/ProductView.tsx
@@ -36,37 +36,36 @@ export default function ProductView({
   });
 
   return (
-    <div className="bg-[#000D34] min-h-screen">
+    <div className="bg-base min-h-screen">
       <JsonLd data={productSchema} />
       <JsonLd data={faqSchema} />
       <JsonLd data={breadcrumbSchema} />
 
-      <div className="max-w-7xl mx-auto px-6 py-16 grid lg:grid-cols-[2fr_1fr] gap-12">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 py-8 sm:py-14 grid lg:grid-cols-[2fr_1fr] gap-8 lg:gap-14">
         {/* ================= CONTEÚDO PRINCIPAL ================= */}
-        <section className="space-y-14">
-          {/* ================= PRODUTO ================= */}
-          <div className="bg-[#0a154a] rounded-3xl border border-[#45C4B0] p-8 shadow-lg">
+        <section className="space-y-6 sm:space-y-8">
+          {/* PRODUTO */}
+          <div className="bg-panel rounded-2xl sm:rounded-3xl shadow-elevated border border-line p-4 sm:p-8">
             <ProductDetails product={produto} />
           </div>
 
-          {/* ================= ANÁLISE ================= */}
-          <div className="bg-[#0a154a] rounded-3xl border border-[#45C4B0] p-8 shadow-lg">
+          {/* ANÁLISE */}
+          <div className="bg-panel rounded-2xl sm:rounded-3xl shadow-elevated border border-line p-4 sm:p-8">
             <ProductPriceAnalysis analytics={analytics} decision={decision} />
           </div>
 
-          {/* ================= INDICADORES ================= */}
-          <div className="bg-[#0a154a] rounded-3xl border border-[#45C4B0] p-8 shadow-lg">
-            <h2 className="text-2xl font-bold mb-8 text-[#9AEBA3]">
+          {/* INDICADORES */}
+          <div className="bg-panel rounded-2xl sm:rounded-3xl shadow-elevated border border-line p-4 sm:p-8">
+            <h2 className="text-lg sm:text-2xl font-bold mb-4 sm:mb-6 text-ink">
               📊 Indicadores de preço
             </h2>
 
-            <div className="grid grid-cols-1 sm:grid-cols-3 gap-6">
-              {/* MENOR PREÇO */}
-              <div className="bg-[#000D34] rounded-2xl p-6 border border-[#45C4B0]">
-                <p className="text-sm text-[#45C4B0] font-semibold mb-2">
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 sm:gap-6">
+              <div className="bg-success/10 rounded-xl sm:rounded-2xl p-4 sm:p-6 border border-success/30">
+                <p className="text-xs sm:text-sm text-success font-medium mb-1 sm:mb-2">
                   Menor preço histórico
                 </p>
-                <p className="text-2xl font-extrabold text-[#F5F138]">
+                <p className="text-lg sm:text-2xl font-bold text-success">
                   {analytics.metrics.minPrice.toLocaleString("pt-BR", {
                     style: "currency",
                     currency: "BRL",
@@ -74,12 +73,11 @@ export default function ProductView({
                 </p>
               </div>
 
-              {/* MAIOR PREÇO */}
-              <div className="bg-[#000D34] rounded-2xl p-6 border border-[#45C4B0]">
-                <p className="text-sm text-[#45C4B0] font-semibold mb-2">
+              <div className="bg-danger/10 rounded-xl sm:rounded-2xl p-4 sm:p-6 border border-danger/30">
+                <p className="text-xs sm:text-sm text-danger font-medium mb-1 sm:mb-2">
                   Maior preço histórico
                 </p>
-                <p className="text-2xl font-extrabold text-[#9AEBA3]">
+                <p className="text-lg sm:text-2xl font-bold text-danger">
                   {analytics.metrics.maxPrice.toLocaleString("pt-BR", {
                     style: "currency",
                     currency: "BRL",
@@ -87,20 +85,25 @@ export default function ProductView({
                 </p>
               </div>
 
-              {/* DECISÃO */}
-              <div className="bg-[#000D34] rounded-2xl p-6 border border-[#45C4B0]">
-                <p className="text-sm text-[#45C4B0] font-semibold mb-2">
+              <div
+                className={`rounded-xl sm:rounded-2xl p-4 sm:p-6 border ${decision.bg}`}
+              >
+                <p
+                  className={`text-xs sm:text-sm font-medium mb-1 sm:mb-2 ${decision.color}`}
+                >
                   Comparação com a média
                 </p>
-                <p className="text-xl font-bold text-[#F5F138]">
+                <p
+                  className={`text-base sm:text-xl font-bold ${decision.color}`}
+                >
                   {decision.title}
                 </p>
               </div>
             </div>
           </div>
 
-          {/* ================= HISTÓRICO ================= */}
-          <div className="bg-[#0a154a] rounded-3xl border border-[#45C4B0] p-8 shadow-lg">
+          {/* HISTÓRICO */}
+          <div className="bg-panel rounded-2xl sm:rounded-3xl shadow-elevated border border-line p-4 sm:p-8">
             <ProductHistory
               data={priceHistory}
               lowerDomain={analytics.metrics.lowerDomain}
@@ -111,10 +114,8 @@ export default function ProductView({
 
         {/* ================= SIDEBAR ================= */}
         <aside className="mt-12 lg:mt-0">
-          <div className="lg:sticky lg:top-28 space-y-8">
-            <div className="bg-[#0a154a] rounded-3xl border border-[#45C4B0] p-6 shadow-lg">
-              <SimilarProducts products={productData.similares} />
-            </div>
+          <div className="lg:sticky lg:top-28">
+            <SimilarProducts products={productData.similares} />
           </div>
         </aside>
       </div>

--- a/promoly-next/src/features/product/components/SimilarProducts.tsx
+++ b/promoly-next/src/features/product/components/SimilarProducts.tsx
@@ -12,26 +12,22 @@ export default function SimilarProducts({ products }: Props) {
   if (!products || products.length === 0) return null;
 
   return (
-    <aside className="bg-[#DAFDBA] rounded-3xl border border-[#45C4B0] p-6 shadow-lg">
-      <h3 className="text-lg font-bold mb-6 text-[#000D34] flex items-center gap-2">
+    <aside className="bg-panel rounded-3xl border border-line p-6 shadow-elevated">
+
+      <h3 className="text-lg font-semibold mb-6 text-ink flex items-center gap-2">
         🔁 Produtos semelhantes
       </h3>
 
-      <div className="flex flex-col gap-4">
+      <div className="flex flex-col gap-3">
+
         {products.map((p) => (
           <Link
             key={p.produto_id}
             href={`/produto/${p.slug}`}
-            className="
-              flex gap-4 p-4 rounded-xl
-              bg-white
-              border border-[#45C4B0]
-              hover:bg-[#CFF5A8]
-              transition
-            "
+            className="flex gap-4 p-3 rounded-xl transition border border-line bg-panel-subtle hover:bg-panel-elevated hover:border-primary/40"
           >
-            {/* IMAGEM */}
-            <div className="w-16 h-16 relative flex-shrink-0 bg-white rounded-lg p-2 border border-[#45C4B0]">
+
+            <div className="w-16 h-16 relative flex-shrink-0 bg-white rounded-lg p-2">
               <Image
                 src={p.imagem_url ?? "/placeholder.png"}
                 alt={p.titulo}
@@ -40,14 +36,13 @@ export default function SimilarProducts({ products }: Props) {
               />
             </div>
 
-            {/* TEXTO */}
             <div className="flex flex-col gap-1 flex-1">
-              <p className="text-sm font-semibold line-clamp-2 text-[#000D34]">
+              <p className="text-sm font-medium line-clamp-2 text-ink">
                 {p.titulo}
               </p>
 
               {p.preco !== null && (
-                <p className="text-[#000D34] font-bold text-sm">
+                <p className="text-success font-semibold text-sm">
                   {p.preco.toLocaleString("pt-BR", {
                     style: "currency",
                     currency: "BRL",
@@ -55,9 +50,12 @@ export default function SimilarProducts({ products }: Props) {
                 </p>
               )}
             </div>
+
           </Link>
         ))}
+
       </div>
+
     </aside>
   );
 }

--- a/promoly-next/src/features/product/utils/productDecision.ts
+++ b/promoly-next/src/features/product/utils/productDecision.ts
@@ -13,7 +13,7 @@ export function getPurchaseDecision(diff: number): PurchaseDecision {
       description:
         "O preço está muito abaixo da média histórica. Forte indicação de oportunidade.",
       color: "text-success",
-      bg: "bg-success-light border-success",
+      bg: "bg-success/10 border-success/40",
       icon: "🟢",
     };
   }
@@ -23,7 +23,7 @@ export function getPurchaseDecision(diff: number): PurchaseDecision {
       title: "Bom momento para comprar",
       description: "O preço está abaixo da média histórica.",
       color: "text-success",
-      bg: "bg-success-light border-success",
+      bg: "bg-success/10 border-success/40",
       icon: "🟢",
     };
   }
@@ -32,8 +32,8 @@ export function getPurchaseDecision(diff: number): PurchaseDecision {
     return {
       title: "Preço dentro da média",
       description: "O preço está alinhado com a média histórica.",
-      color: "text-gray-700",
-      bg: "bg-gray-100 border-gray-300",
+      color: "text-accent",
+      bg: "bg-accent/10 border-accent/40",
       icon: "🟡",
     };
   }
@@ -42,7 +42,7 @@ export function getPurchaseDecision(diff: number): PurchaseDecision {
     title: "Momento desfavorável para compra",
     description: "O preço está acima da média histórica.",
     color: "text-danger",
-    bg: "bg-red-50 border-danger",
+    bg: "bg-danger/10 border-danger/40",
     icon: "🔴",
   };
 }

--- a/promoly-next/tailwind.config.js
+++ b/promoly-next/tailwind.config.js
@@ -14,20 +14,21 @@ module.exports = {
         ========================== */
 
         primary: {
-          DEFAULT: "#2563eb",
-          hover: "#1d4ed8",
+          DEFAULT: "#3b82f6",
+          hover: "#2563eb",
         },
 
         success: {
-          DEFAULT: "#22c177",
+          DEFAULT: "#22c55e",
+          glow: "#34d399",
         },
 
         accent: {
-          DEFAULT: "#facc15",
+          DEFAULT: "#fbbf24",
         },
 
         danger: {
-          DEFAULT: "#dc2626",
+          DEFAULT: "#ef4444",
         },
 
         muted: {
@@ -38,11 +39,29 @@ module.exports = {
           DEFAULT: "#ffffff",
           subtle: "#f3f4f6",
         },
+
+        /* =========================
+           DARK PREMIUM SYSTEM
+        ========================== */
+        base: "#0a0e1a",
+        panel: {
+          DEFAULT: "#111726",
+          elevated: "#161d2e",
+          subtle: "#1c2435",
+        },
+        ink: {
+          DEFAULT: "#f1f5f9",
+          muted: "#94a3b8",
+          faint: "#64748b",
+        },
+        line: "#1f2a3d",
       },
 
       boxShadow: {
         soft: "0 4px 12px rgba(0,0,0,0.05)",
         medium: "0 8px 20px rgba(0,0,0,0.08)",
+        glow: "0 0 0 1px rgba(34,197,94,0.25), 0 8px 30px rgba(34,197,94,0.12)",
+        elevated: "0 10px 40px rgba(0,0,0,0.45)",
       },
 
       borderRadius: {

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,8 @@ python-dateutil>=2.9.0
 # =========================
 pytest>=8.0.0
 pytest-cov>=4.1.0
+pytest-mock>=3.12.0
+factory-boy>=3.3.0
 
 # =========================
 # Typing / compat

--- a/scrapper_mlb/block_detection.py
+++ b/scrapper_mlb/block_detection.py
@@ -1,0 +1,29 @@
+"""Detecção unificada de página de bloqueio do Mercado Livre.
+
+Antes a lógica vivia duplicada em dois lugares com markers diferentes:
+- `http_client.is_blocked` (camada de listagem)
+- `update_service.is_block_page` (camada de página de produto)
+
+Aqui ficam os markers consolidados, num único ponto de manutenção.
+"""
+
+# Markers verificados como substring no HTML em minúsculas. Cobre tanto
+# páginas antifraude (captcha/tráfego suspeito) quanto telas de verificação
+# de conta. As classes CSS (.account-verification-header, .new-user-button)
+# aparecem como texto no markup, então o match por substring as cobre.
+BLOCK_MARKERS = [
+    "captcha",
+    "verify you are human",
+    "access denied",
+    "unusual traffic",
+    "suspicious_traffic",
+    "account-verification",
+    "new-user-button",
+    "olá! para continuar, acesse",
+]
+
+
+def is_blocked(html: str) -> bool:
+    """True se o HTML parece uma página de bloqueio/verificação do ML."""
+    html_lower = html.lower()
+    return any(marker in html_lower for marker in BLOCK_MARKERS)

--- a/scrapper_mlb/config.py
+++ b/scrapper_mlb/config.py
@@ -3,13 +3,34 @@ import os
 load_dotenv()
 URL_MLB_BASE = os.getenv("URL_MLB_BASE")
 
-HEADERS = {
-    "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36",
+import random
+
+# Pool de User-Agents para rotação — fingerprint estático único é fácil de
+# bloquear em escala. A cada request escolhe-se um UA aleatório.
+USER_AGENTS = [
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36",
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36",
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:123.0) Gecko/20100101 Firefox/123.0",
+    "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:122.0) Gecko/20100101 Firefox/122.0",
+]
+
+# Headers base (sem User-Agent, que é injetado por request via build_headers).
+BASE_HEADERS = {
     "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
     "Accept-Language": "pt-BR,pt;q=0.9,en;q=0.8",
     "Connection": "keep-alive",
     "Upgrade-Insecure-Requests": "1",
 }
+
+
+def build_headers() -> dict:
+    """Monta headers com um User-Agent aleatório do pool."""
+    return {**BASE_HEADERS, "User-Agent": random.choice(USER_AGENTS)}
+
+
+# Compat: HEADERS continua disponível (UA fixo do pool) para quem importa.
+HEADERS = {**BASE_HEADERS, "User-Agent": USER_AGENTS[0]}
 
 
 CATEGORIES = {

--- a/scrapper_mlb/http_client.py
+++ b/scrapper_mlb/http_client.py
@@ -1,4 +1,5 @@
 import random
+import threading
 import time
 from pathlib import Path
 
@@ -20,15 +21,19 @@ class BackoffController:
         self.max_delay = max_delay
         self.factor = factor
         self.current_delay = base_delay
+        self._lock = threading.Lock()
 
     def success(self):
-        self.current_delay = self.base_delay
+        with self._lock:
+            self.current_delay = self.base_delay
 
     def error(self):
-        self.current_delay = min(self.current_delay * self.factor, self.max_delay)
+        with self._lock:
+            self.current_delay = min(self.current_delay * self.factor, self.max_delay)
 
     def wait(self):
-        delay = random.uniform(self.current_delay * 0.8, self.current_delay * 1.2)
+        with self._lock:
+            delay = random.uniform(self.current_delay * 0.8, self.current_delay * 1.2)
         time.sleep(delay)
 
 
@@ -36,15 +41,19 @@ class RateLimiter:
     def __init__(self, min_interval: float):
         self.min_interval = min_interval
         self.last_request = 0.0
+        self._lock = threading.Lock()
 
     def wait(self):
-        now = time.time()
-        elapsed = now - self.last_request
+        # Serializa as threads: mantém o lock durante o sleep para que o
+        # intervalo mínimo seja respeitado globalmente, não por thread.
+        with self._lock:
+            now = time.time()
+            elapsed = now - self.last_request
 
-        if elapsed < self.min_interval:
-            time.sleep(self.min_interval - elapsed)
+            if elapsed < self.min_interval:
+                time.sleep(self.min_interval - elapsed)
 
-        self.last_request = time.time()
+            self.last_request = time.time()
 
 
 # 🔥 Use apenas uma instância

--- a/scrapper_mlb/http_client.py
+++ b/scrapper_mlb/http_client.py
@@ -1,3 +1,5 @@
+import hashlib
+import os
 import random
 import threading
 import time
@@ -6,14 +8,27 @@ from pathlib import Path
 import requests
 
 from scrapper_mlb.block_detection import is_blocked
-from scrapper_mlb.config import HEADERS
+from scrapper_mlb.config import HEADERS, build_headers
 
 
-DEBUG_PATH = Path("scrapper_mlb_debug.html")
+# Diretório de debug; cada URL gera um arquivo único para evitar corrida de
+# escrita entre as threads do ThreadPoolExecutor. Só grava se habilitado.
+DEBUG_DIR = Path("debug_html")
+DEBUG_ENABLED = os.getenv("SCRAPER_DEBUG_HTML", "").lower() in ("1", "true", "yes")
+_debug_lock = threading.Lock()
 
 MIN_HTML_SIZE = 50_000
 MAX_HTML_SIZE = 5_000_000
 MAX_RETRIES = 3
+
+
+def _save_debug(url: str, html: str) -> None:
+    if not DEBUG_ENABLED:
+        return
+    nome = hashlib.sha1(url.encode("utf-8")).hexdigest()[:12]
+    with _debug_lock:
+        DEBUG_DIR.mkdir(exist_ok=True)
+        (DEBUG_DIR / f"{nome}.html").write_text(html, encoding="utf-8")
 
 
 class BackoffController:
@@ -72,7 +87,8 @@ def fetch_html(url: str) -> str:
         rate_limiter.wait()
 
         try:
-            response = session.get(url, timeout=20)
+            # 🔄 User-Agent rotacionado por request (rotação de fingerprint)
+            response = session.get(url, timeout=20, headers=build_headers())
             status = response.status_code
             html = response.text
             size = len(html)
@@ -99,9 +115,8 @@ def fetch_html(url: str) -> str:
             if size > MAX_HTML_SIZE:
                 raise RuntimeError(f"HTML muito grande ({size})")
 
-            # 🔥 Salva debug
-            with open(DEBUG_PATH, "w", encoding="utf-8") as f:
-                f.write(html)
+            # 🔥 Salva debug (arquivo único por URL, sem corrida entre threads)
+            _save_debug(url, html)
 
             backoff.success()
             print("✅ HTML válido capturado")

--- a/scrapper_mlb/http_client.py
+++ b/scrapper_mlb/http_client.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import requests
 
+from scrapper_mlb.block_detection import is_blocked
 from scrapper_mlb.config import HEADERS
 
 
@@ -63,21 +64,6 @@ backoff = BackoffController()
 # 🔥 Sessão persistente
 session = requests.Session()
 session.headers.update(HEADERS)
-
-
-def is_blocked(html: str) -> bool:
-    html_lower = html.lower()
-
-    block_markers = [
-        "captcha",
-        "verify you are human",
-        "access denied",
-        "unusual traffic",
-        "suspicious_traffic",
-        "account-verification",
-    ]
-
-    return any(marker in html_lower for marker in block_markers)
 
 
 def fetch_html(url: str) -> str:

--- a/scrapper_mlb/product_page/service/update_service.py
+++ b/scrapper_mlb/product_page/service/update_service.py
@@ -1,28 +1,15 @@
 import os
-import time
 import requests
 from bs4 import BeautifulSoup
+from scrapper_mlb.block_detection import is_blocked
 from scrapper_mlb.config import HEADERS
+from scrapper_mlb.http_client import backoff, rate_limiter
 from scrapper_mlb.product_page.update_builder import build_product_page
 
 DEBUG_DIR = "debug_html"
 
 session = requests.Session()
 session.headers.update(HEADERS)
-
-
-def is_block_page(soup: BeautifulSoup) -> bool:
-    # Detecta bloqueio REAL
-    if soup.select_one(".account-verification-header"):
-        return True
-
-    if soup.select_one(".new-user-button"):
-        return True
-
-    if "Olá! Para continuar, acesse" in soup.get_text():
-        return True
-
-    return False
 
 
 def clean_url(url: str) -> str:
@@ -34,20 +21,24 @@ def _collect_once(url: str, produto_id: int):
     try:
         url = clean_url(url)
 
+        # 🔥 Mesmo rate limiter/backoff da listagem (politeness global)
+        rate_limiter.wait()
         response = session.get(url, timeout=15, allow_redirects=True)
 
         if response.status_code != 200:
             print(f"⚠️ Status inválido: {response.status_code}")
+            backoff.error()
+            return None
+
+        # 🔥 Detecção de bloqueio unificada (block_detection)
+        if is_blocked(response.text):
+            print(f"🚨 BLOQUEIO detectado para ID={produto_id}")
+            backoff.error()
             return None
 
         soup = BeautifulSoup(response.text, "html.parser")
-
-        # 🔥 Detecta bloqueio real
-        if is_block_page(soup):
-            print(f"🚨 BLOQUEIO detectado para ID={produto_id}")
-            return None
-
         page_data = build_product_page(soup)
+        backoff.success()
 
         # 🔥 Debug se não tiver preço
         if page_data.preco is None:
@@ -65,6 +56,7 @@ def _collect_once(url: str, produto_id: int):
 
     except requests.RequestException as e:
         print(f"⚠️ Erro de requisição: {e}")
+        backoff.error()
         return None
 
 
@@ -79,7 +71,9 @@ def collect_product_by_url(url: str, produto_id: int, retries: int = 1):
 
         if attempt < retries:
             print(f"🔁 Retry {attempt + 1}/{retries} para ID={produto_id}")
-            time.sleep(5)
+            # Espera com backoff exponencial (inflado pelo backoff.error()
+            # disparado no _collect_once em caso de erro/bloqueio).
+            backoff.wait()
 
     print(f"❌ Falha definitiva para ID={produto_id}")
     return None

--- a/scrapper_mlb/services/product_service.py
+++ b/scrapper_mlb/services/product_service.py
@@ -6,12 +6,18 @@ from scrapper_mlb.services.url_builder import build_search_url
 
 #///////////
 
+# Acima desta fração de cards falhando, presume-se que o seletor/layout do ML
+# mudou (e não que sejam apenas cards patrocinados/placeholder esparsos).
+FAIL_RATIO_ALERT = 0.6
+
+
 def collect_products(url: str):
     html = fetch_html(url)
     soup = parse_html(html)
     nodes = find_product_nodes(soup)
 
     products = []
+    falhas = 0
 
     for item in nodes:
         try:
@@ -20,7 +26,16 @@ def collect_products(url: str):
         except ValueError:
             # Item não representa um produto válido
             # (card patrocinado, placeholder, layout alternativo, etc.)
+            falhas += 1
             continue
+
+    total = len(nodes)
+    if total and falhas / total >= FAIL_RATIO_ALERT:
+        print(
+            f"🚨 ALERTA: {falhas}/{total} cards falharam na extração "
+            f"({falhas / total:.0%}) — provável quebra de seletor/layout do ML. "
+            f"URL: {url}"
+        )
 
     return products
 

--- a/scrapper_mlb/services/url_builder.py
+++ b/scrapper_mlb/services/url_builder.py
@@ -7,6 +7,10 @@ load_dotenv()
 
 URL_MLB_SEARCH_BASE = os.getenv("URL_MLB_SEARCH_BASE")
 
+# Tamanho da página de busca do ML (offset de paginação _Desde_). Hardcoded
+# antes; agora configurável caso o ML mude o page size.
+ML_PAGE_SIZE = int(os.getenv("ML_PAGE_SIZE", "48"))
+
 
 def build_search_url(
     query: str,
@@ -38,7 +42,7 @@ def build_search_url(
 
     # Paginação: _Desde_49
     if page > 1:
-        offset = (page - 1) * 48 + 1
+        offset = (page - 1) * ML_PAGE_SIZE + 1
         url += f"_Desde_{offset}"
 
     # Filtros adicionais

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -1,0 +1,71 @@
+"""Factories (factory_boy) compartilhadas pelos testes.
+
+Centraliza a construção de objetos de domínio, controladores e respostas
+HTTP falsas, evitando montar objetos à mão em cada teste.
+"""
+from decimal import Decimal
+
+import factory
+
+from scrapper_mlb.http_client import BackoffController, RateLimiter
+from scrapper_mlb.models import Product
+from scrapper_mlb.product_page.models import ProductPageData
+
+
+class ProductFactory(factory.Factory):
+    class Meta:
+        model = Product
+
+    id_produto = factory.Sequence(lambda n: f"MLB{1000 + n}")
+    descricao = factory.Faker("sentence", nb_words=3)
+    preco = factory.LazyFunction(lambda: Decimal("199.90"))
+    avaliacao = factory.LazyFunction(lambda: Decimal("4.5"))
+    desconto = None
+    link = factory.LazyAttribute(
+        lambda o: f"https://produto.mercadolivre.com.br/{o.id_produto}"
+    )
+    imagem_url = "https://http2.mlstatic.com/x.webp"
+    buyers = 100
+    card_hash = factory.Faker("sha256")
+
+
+class ProductPageDataFactory(factory.Factory):
+    class Meta:
+        model = ProductPageData
+
+    preco = factory.LazyFunction(lambda: Decimal("149.90"))
+    avaliacao = factory.LazyFunction(lambda: Decimal("4.2"))
+    status = None
+
+
+class RateLimiterFactory(factory.Factory):
+    class Meta:
+        model = RateLimiter
+
+    min_interval = 0.05
+
+
+class BackoffControllerFactory(factory.Factory):
+    class Meta:
+        model = BackoffController
+
+    base_delay = 0.01
+    max_delay = 0.1
+    factor = 2.0
+
+
+class FakeResponse:
+    """Resposta HTTP mínima compatível com o uso em update_service."""
+
+    def __init__(self, status_code: int = 200, text: str = ""):
+        self.status_code = status_code
+        self.text = text
+
+
+class FakeResponseFactory(factory.Factory):
+    class Meta:
+        model = FakeResponse
+
+    status_code = 200
+    # HTML "válido" o suficiente para não bater nos markers de bloqueio.
+    text = "<html><body>ui-search-layout__item produto ok</body></html>"

--- a/tests/unit/test_affiliate_driver.py
+++ b/tests/unit/test_affiliate_driver.py
@@ -1,0 +1,56 @@
+"""Cobre a consolidação e a configuração por ambiente do create_driver
+(pontos #7 e #8 da issue #52)."""
+import pytest
+
+from affiliate import driver as driver_mod
+
+
+@pytest.fixture
+def fake_chrome(mocker):
+    """Evita subir Chrome real; devolve o Options capturado."""
+    chrome = mocker.patch.object(driver_mod.webdriver, "Chrome")
+
+    def _options():
+        # webdriver.Chrome(options=options) -> kwarg
+        _, kwargs = chrome.call_args
+        return kwargs["options"]
+
+    chrome.options = _options
+    return chrome
+
+
+@pytest.mark.unit
+def test_create_driver_usa_env_profile_dir(mocker, fake_chrome):
+    mocker.patch.dict(
+        "os.environ",
+        {"SELENIUM_PROFILE_DIR": "/custom/profile", "SELENIUM_PROFILE_NAME": "Bot"},
+    )
+
+    driver_mod.create_driver()
+
+    args = fake_chrome.options().arguments
+    assert "--user-data-dir=/custom/profile" in args
+    assert "--profile-directory=Bot" in args
+
+
+@pytest.mark.unit
+def test_create_driver_default_sem_env(mocker, fake_chrome):
+    mocker.patch.dict("os.environ", {}, clear=True)
+
+    driver_mod.create_driver()
+
+    args = fake_chrome.options().arguments
+    assert f"--user-data-dir={driver_mod.DEFAULT_PROFILE_DIR}" in args
+    assert "--profile-directory=Default" in args
+    # default derivado do HOME, não um caminho de máquina hardcoded
+    import os
+    assert driver_mod.DEFAULT_PROFILE_DIR == os.path.expanduser(
+        "~/selenium-chromium-profile"
+    )
+
+
+@pytest.mark.unit
+def test_mlb_affiliate_reexporta_mesmo_create_driver():
+    from affiliate.mlb_affiliate import create_driver as via_mlb
+
+    assert via_mlb is driver_mod.create_driver

--- a/tests/unit/test_affiliate_worker.py
+++ b/tests/unit/test_affiliate_worker.py
@@ -1,0 +1,86 @@
+"""Cobre a robustez do worker de afiliado: espera real pelo link (#9) e
+restart periódico do driver (#10) da issue #52."""
+import pytest
+from selenium.common.exceptions import TimeoutException
+
+from affiliate import mlb_affiliate
+from affiliate import main as worker_main
+
+
+# ---------------------------------------------------------------------------
+# #9 — gerar_link_afiliado espera o link aparecer em vez de sleep fixo
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def driver(mocker):
+    return mocker.MagicMock(name="driver")
+
+
+@pytest.fixture(autouse=True)
+def no_sleep(mocker):
+    mocker.patch.object(mlb_affiliate.time, "sleep")
+
+
+@pytest.mark.unit
+def test_gerar_link_retorna_quando_link_aparece(mocker, driver):
+    wait = mocker.MagicMock(name="wait")
+    # WebDriverWait(...).until() devolve sem estourar -> link disponível
+    fake_wait = mocker.patch.object(mlb_affiliate, "WebDriverWait")
+    fake_wait.return_value.until.return_value = True
+    mocker.patch.object(
+        mlb_affiliate, "extrair_link_afiliado", return_value="http://aff/x"
+    )
+
+    link = mlb_affiliate.gerar_link_afiliado(driver, wait, "http://prod/MLB1")
+
+    assert link == "http://aff/x"
+    fake_wait.assert_called_once_with(driver, mlb_affiliate.RESULT_TIMEOUT)
+
+
+@pytest.mark.unit
+def test_gerar_link_retorna_none_em_timeout(mocker, driver):
+    wait = mocker.MagicMock(name="wait")
+    fake_wait = mocker.patch.object(mlb_affiliate, "WebDriverWait")
+    fake_wait.return_value.until.side_effect = TimeoutException()
+    mocker.patch.object(mlb_affiliate, "extrair_link_afiliado", return_value=None)
+
+    link = mlb_affiliate.gerar_link_afiliado(driver, wait, "http://prod/MLB1")
+
+    assert link is None
+
+
+# ---------------------------------------------------------------------------
+# #10 — restart_driver encerra o driver antigo e devolve um novo
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_restart_driver_encerra_e_recria(mocker):
+    old = mocker.MagicMock(name="old_driver")
+    novo = mocker.MagicMock(name="novo_driver")
+    create = mocker.patch.object(worker_main, "create_driver", return_value=novo)
+    mocker.patch.object(worker_main, "WebDriverWait", return_value="wait_obj")
+
+    driver, wait = worker_main.restart_driver(old)
+
+    old.quit.assert_called_once()
+    create.assert_called_once()
+    assert driver is novo
+    assert wait == "wait_obj"
+
+
+@pytest.mark.unit
+def test_restart_driver_ignora_erro_no_quit(mocker):
+    old = mocker.MagicMock(name="old_driver")
+    old.quit.side_effect = Exception("já morto")
+    novo = mocker.MagicMock(name="novo_driver")
+    mocker.patch.object(worker_main, "create_driver", return_value=novo)
+    mocker.patch.object(worker_main, "WebDriverWait", return_value="wait_obj")
+
+    driver, _ = worker_main.restart_driver(old)
+
+    assert driver is novo  # erro no quit não derruba o restart
+
+
+@pytest.mark.unit
+def test_restart_every_configurado():
+    assert worker_main.RESTART_DRIVER_EVERY > 0

--- a/tests/unit/test_block_detection.py
+++ b/tests/unit/test_block_detection.py
@@ -1,0 +1,39 @@
+import pytest
+
+from scrapper_mlb.block_detection import is_blocked
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "html",
+    [
+        "<html>Please solve the CAPTCHA</html>",
+        "<html>verify you are human</html>",
+        "<html>Access Denied</html>",
+        "<html>unusual traffic detected</html>",
+        "<div class='suspicious_traffic'></div>",
+        "<header class='account-verification-header'></header>",
+        "<button class='new-user-button'>x</button>",
+        "<p>Olá! Para continuar, acesse sua conta</p>",
+    ],
+)
+def test_is_blocked_detecta_markers(html):
+    assert is_blocked(html) is True
+
+
+@pytest.mark.unit
+def test_is_blocked_case_insensitive():
+    assert is_blocked("ACCOUNT-VERIFICATION") is True
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "html",
+    [
+        "<html><body>ui-search-layout__item produto normal</body></html>",
+        "<div class='andes-money-amount__fraction'>199</div>",
+        "",
+    ],
+)
+def test_is_blocked_pagina_normal(html):
+    assert is_blocked(html) is False

--- a/tests/unit/test_collect_products_alert.py
+++ b/tests/unit/test_collect_products_alert.py
@@ -1,0 +1,83 @@
+"""Cobre o alerta de quebra de seletor/layout (ponto #2 da issue #52).
+
+collect_products deve emitir alerta quando a maioria dos cards falha na
+extração, em vez de engolir tudo silenciosamente no `except ValueError`.
+"""
+import pytest
+
+from scrapper_mlb.services import product_service
+from scrapper_mlb.services.product_service import FAIL_RATIO_ALERT
+from tests.factories import ProductFactory
+
+
+@pytest.fixture
+def patch_pipeline(mocker):
+    """Neutraliza fetch/parse; cada nó é só um sentinela inteiro."""
+    mocker.patch.object(product_service, "fetch_html", return_value="<html>")
+    mocker.patch.object(product_service, "parse_html", return_value=object())
+
+    def _setup(n_nodes):
+        nodes = list(range(n_nodes))
+        mocker.patch.object(
+            product_service, "find_product_nodes", return_value=nodes
+        )
+        return nodes
+
+    return _setup
+
+
+def _build_side_effect(falhas: int):
+    """build_product: as `falhas` primeiras chamadas levantam ValueError."""
+    estado = {"chamadas": 0}
+
+    def _fake(item):
+        estado["chamadas"] += 1
+        if estado["chamadas"] <= falhas:
+            raise ValueError("seletor quebrado")
+        return ProductFactory()
+
+    return _fake
+
+
+@pytest.mark.unit
+def test_alerta_quando_maioria_falha(mocker, capsys, patch_pipeline):
+    patch_pipeline(10)
+    mocker.patch.object(
+        product_service, "build_product", side_effect=_build_side_effect(8)
+    )
+
+    produtos = product_service.collect_products("http://x")
+
+    out = capsys.readouterr().out
+    assert "🚨 ALERTA" in out
+    assert "8/10" in out
+    assert len(produtos) == 2
+
+
+@pytest.mark.unit
+def test_sem_alerta_quando_poucas_falhas(mocker, capsys, patch_pipeline):
+    patch_pipeline(10)
+    # 2/10 = 20% < 60%: cards patrocinados esparsos, sem alerta
+    mocker.patch.object(
+        product_service, "build_product", side_effect=_build_side_effect(2)
+    )
+
+    produtos = product_service.collect_products("http://x")
+
+    out = capsys.readouterr().out
+    assert "ALERTA" not in out
+    assert len(produtos) == 8
+
+
+@pytest.mark.unit
+def test_limiar_no_threshold_exato(mocker, capsys, patch_pipeline):
+    n = 10
+    falhas = int(n * FAIL_RATIO_ALERT)  # 6/10 == 60% -> alerta (>=)
+    patch_pipeline(n)
+    mocker.patch.object(
+        product_service, "build_product", side_effect=_build_side_effect(falhas)
+    )
+
+    product_service.collect_products("http://x")
+
+    assert "ALERTA" in capsys.readouterr().out

--- a/tests/unit/test_http_client_threadsafe.py
+++ b/tests/unit/test_http_client_threadsafe.py
@@ -1,0 +1,90 @@
+"""Cobre a thread-safety do RateLimiter e do BackoffController (ponto #1
+da issue #52). collect_products_by_query roda páginas em paralelo via
+ThreadPoolExecutor, então esses controladores globais precisam de lock."""
+import threading
+import time
+
+import pytest
+
+from tests.factories import BackoffControllerFactory, RateLimiterFactory
+
+
+@pytest.mark.unit
+def test_controladores_tem_lock():
+    rl = RateLimiterFactory()
+    bo = BackoffControllerFactory()
+    assert isinstance(rl._lock, type(threading.Lock()))
+    assert isinstance(bo._lock, type(threading.Lock()))
+
+
+@pytest.mark.unit
+def test_rate_limiter_serializa_threads():
+    # 5 threads, intervalo 0.05s. A 1ª passa direto; as 4 seguintes ficam
+    # serializadas pelo lock => tempo total >= ~4 * intervalo.
+    interval = 0.05
+    rl = RateLimiterFactory(min_interval=interval)
+
+    barrier = threading.Barrier(5)
+
+    def worker():
+        barrier.wait()
+        rl.wait()
+
+    threads = [threading.Thread(target=worker) for _ in range(5)]
+
+    start = time.time()
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    elapsed = time.time() - start
+
+    assert elapsed >= 4 * interval * 0.8  # margem p/ jitter de scheduling
+
+
+@pytest.mark.unit
+def test_backoff_concorrente_nao_corrompe_estado():
+    # Muitas threads alternando error/success não devem estourar exceção
+    # nem deixar current_delay fora dos limites.
+    bo = BackoffControllerFactory(base_delay=0.01, max_delay=0.1, factor=2.0)
+
+    def worker():
+        for _ in range(200):
+            bo.error()
+            bo.success()
+
+    threads = [threading.Thread(target=worker) for _ in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert bo.base_delay <= bo.current_delay <= bo.max_delay
+
+
+@pytest.mark.unit
+def test_backoff_error_cresce_e_satura(mocker):
+    bo = BackoffControllerFactory(base_delay=1.0, max_delay=4.0, factor=2.0)
+
+    bo.error()
+    assert bo.current_delay == 2.0
+    bo.error()
+    assert bo.current_delay == 4.0
+    bo.error()
+    assert bo.current_delay == 4.0  # satura no max_delay
+    bo.success()
+    assert bo.current_delay == 1.0  # reseta para base_delay
+
+
+@pytest.mark.unit
+def test_rate_limiter_respeita_intervalo_sequencial(mocker):
+    interval = 0.05
+    rl = RateLimiterFactory(min_interval=interval)
+
+    sleeps = []
+    mocker.patch("time.sleep", side_effect=lambda d: sleeps.append(d))
+
+    rl.wait()  # primeira: last_request=0, sem espera relevante
+    rl.wait()  # segunda: deve dormir ~interval
+
+    assert any(s > 0 for s in sleeps)

--- a/tests/unit/test_linkbuilder_decoupling.py
+++ b/tests/unit/test_linkbuilder_decoupling.py
@@ -1,0 +1,167 @@
+"""
+Testes de desacoplamento do worker de afiliado em relação à UI PT-BR
+do linkbuilder do Mercado Livre.
+
+Cobre:
+(a) seletores configuráveis por env var são usados;
+(b) fallback de múltiplos textos do botão "Gerar";
+(c) retorno do link quando extrair_link_afiliado devolve um link;
+(d) comportamento quando o botão "Gerar" não é encontrado.
+"""
+
+import importlib
+
+import pytest
+from unittest.mock import MagicMock
+
+import affiliate.mlb_affiliate as mlb
+
+
+@pytest.fixture
+def driver():
+    """Driver Selenium mockado."""
+    drv = MagicMock(name="driver")
+    drv.page_source = "<html>conteúdo</html>"
+    return drv
+
+
+@pytest.fixture
+def wait():
+    """WebDriverWait mockado; .until() devolve um elemento mockado."""
+    w = MagicMock(name="wait")
+    w.until.return_value = MagicMock(name="elemento")
+    return w
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep(mocker):
+    """Evita esperas reais durante os testes."""
+    mocker.patch.object(mlb.time, "sleep")
+
+
+def _recarrega_modulo():
+    """Recarrega o módulo para reavaliar as constantes lidas de env."""
+    return importlib.reload(mlb)
+
+
+# ---------------------------------------------------------------------------
+# (a) Seletores configuráveis por env var
+# ---------------------------------------------------------------------------
+
+def test_textarea_id_configuravel_por_env(monkeypatch, driver, wait, mocker):
+    monkeypatch.setenv("LINKBUILDER_TEXTAREA_ID", "campo-custom")
+    mod = _recarrega_modulo()
+    mocker.patch.object(mod, "extrair_link_afiliado", return_value=None)
+    # espiona o construtor de condição para inspecionar os locators usados
+    spy = mocker.spy(mod.EC, "presence_of_element_located")
+
+    assert mod.LINKBUILDER_TEXTAREA_ID == "campo-custom"
+
+    mod.gerar_link_afiliado(driver, wait, "https://produto")
+
+    # primeira condição deve localizar o textarea pelo ID custom
+    primeiro_locator = spy.call_args_list[0].args[0]
+    assert primeiro_locator[1] == "campo-custom"
+
+    monkeypatch.delenv("LINKBUILDER_TEXTAREA_ID")
+    _recarrega_modulo()
+
+
+def test_gerar_texts_configuravel_por_env(monkeypatch):
+    monkeypatch.setenv("LINKBUILDER_GERAR_TEXTS", "Gerar, Generate ,Generar")
+    mod = _recarrega_modulo()
+
+    assert mod.LINKBUILDER_GERAR_TEXTS == ["Gerar", "Generate", "Generar"]
+
+    monkeypatch.delenv("LINKBUILDER_GERAR_TEXTS")
+    _recarrega_modulo()
+
+
+# ---------------------------------------------------------------------------
+# (b) Fallback de múltiplos textos do botão
+# ---------------------------------------------------------------------------
+
+def test_xpath_botao_cobre_multiplos_idiomas():
+    mod = _recarrega_modulo()
+    xpath = mod._xpath_botao_gerar(["Gerar", "Generate"])
+    assert "normalize-space()='Gerar'" in xpath
+    assert "normalize-space()='Generate'" in xpath
+    assert " or " in xpath
+
+
+def test_botao_gerar_usa_xpath_com_textos_configurados(
+    monkeypatch, driver, wait, mocker
+):
+    monkeypatch.setenv("LINKBUILDER_GERAR_TEXTS", "Gerar,Generate")
+    mod = _recarrega_modulo()
+    mocker.patch.object(mod, "extrair_link_afiliado", return_value=None)
+    spy = mocker.spy(mod.EC, "presence_of_element_located")
+
+    mod.gerar_link_afiliado(driver, wait, "https://produto")
+
+    # segunda condição localiza o botão "Gerar" via XPath multilíngue
+    locator = spy.call_args_list[1].args[0]
+    assert locator[0].lower() == "xpath"
+    assert "Gerar" in locator[1]
+    assert "Generate" in locator[1]
+
+    monkeypatch.delenv("LINKBUILDER_GERAR_TEXTS")
+    _recarrega_modulo()
+
+
+# ---------------------------------------------------------------------------
+# (c) Retorno do link
+# ---------------------------------------------------------------------------
+
+def test_retorna_link_quando_extrator_devolve_link(driver, wait, mocker):
+    mod = _recarrega_modulo()
+    mocker.patch.object(
+        mod, "extrair_link_afiliado", return_value="https://mercadolivre.com/sec/abc"
+    )
+
+    link = mod.gerar_link_afiliado(driver, wait, "https://produto")
+
+    assert link == "https://mercadolivre.com/sec/abc"
+
+
+def test_retorna_none_quando_extrator_devolve_none(driver, wait, mocker):
+    mod = _recarrega_modulo()
+    mocker.patch.object(mod, "extrair_link_afiliado", return_value=None)
+
+    link = mod.gerar_link_afiliado(driver, wait, "https://produto")
+
+    assert link is None
+
+
+# ---------------------------------------------------------------------------
+# (d) Botão não encontrado
+# ---------------------------------------------------------------------------
+
+def test_erro_claro_quando_botao_nao_encontrado(driver, mocker):
+    mod = _recarrega_modulo()
+    mocker.patch.object(mod, "extrair_link_afiliado", return_value=None)
+
+    wait = MagicMock(name="wait")
+    elemento_textarea = MagicMock(name="textarea")
+
+    # primeira chamada (.until p/ textarea) ok; segunda (.until p/ botão) falha
+    wait.until.side_effect = [elemento_textarea, Exception("timeout")]
+
+    with pytest.raises(RuntimeError) as exc:
+        mod.gerar_link_afiliado(driver, wait, "https://produto")
+
+    assert "Gerar" in str(exc.value)
+
+
+def test_erro_quando_lista_de_textos_vazia(monkeypatch, driver, wait, mocker):
+    monkeypatch.setenv("LINKBUILDER_GERAR_TEXTS", " , ")
+    mod = _recarrega_modulo()
+    mocker.patch.object(mod, "extrair_link_afiliado", return_value=None)
+
+    assert mod.LINKBUILDER_GERAR_TEXTS == []
+
+    with pytest.raises(ValueError):
+        mod.gerar_link_afiliado(driver, wait, "https://produto")
+
+    monkeypatch.delenv("LINKBUILDER_GERAR_TEXTS")
+    _recarrega_modulo()

--- a/tests/unit/test_listing_hardening.py
+++ b/tests/unit/test_listing_hardening.py
@@ -1,0 +1,83 @@
+"""Cobre o hardening da camada de listagem: rotação de User-Agent (#5),
+debug sem corrida entre threads (#4) e page size configurável (#6)."""
+import importlib
+
+import pytest
+
+from scrapper_mlb import config
+from scrapper_mlb import http_client
+from scrapper_mlb.services import url_builder
+
+
+# ---------------------------------------------------------------------------
+# #5 — rotação de User-Agent
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_build_headers_usa_ua_do_pool():
+    headers = config.build_headers()
+    assert headers["User-Agent"] in config.USER_AGENTS
+    # mantém os headers base
+    assert headers["Accept-Language"].startswith("pt-BR")
+
+
+@pytest.mark.unit
+def test_build_headers_rotaciona(mocker):
+    # força UAs distintos em chamadas consecutivas
+    mocker.patch.object(
+        config.random, "choice", side_effect=[config.USER_AGENTS[0], config.USER_AGENTS[1]]
+    )
+    a = config.build_headers()["User-Agent"]
+    b = config.build_headers()["User-Agent"]
+    assert a != b
+
+
+# ---------------------------------------------------------------------------
+# #4 — debug não escreve por padrão e usa arquivo único por URL
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_save_debug_desabilitado_por_padrao(mocker, tmp_path):
+    mocker.patch.object(http_client, "DEBUG_ENABLED", False)
+    mocker.patch.object(http_client, "DEBUG_DIR", tmp_path)
+
+    http_client._save_debug("http://x/MLB1", "<html>")
+
+    assert list(tmp_path.glob("*.html")) == []  # nada escrito quando desabilitado
+
+
+@pytest.mark.unit
+def test_save_debug_arquivo_unico_por_url(mocker, tmp_path):
+    mocker.patch.object(http_client, "DEBUG_ENABLED", True)
+    mocker.patch.object(http_client, "DEBUG_DIR", tmp_path)
+
+    http_client._save_debug("http://x/MLB1", "<html>1</html>")
+    http_client._save_debug("http://x/MLB2", "<html>2</html>")
+
+    arquivos = list(tmp_path.glob("*.html"))
+    assert len(arquivos) == 2  # URLs diferentes -> arquivos diferentes
+
+
+# ---------------------------------------------------------------------------
+# #6 — page size configurável
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+def test_offset_usa_page_size_default(monkeypatch):
+    monkeypatch.setenv("URL_MLB_SEARCH_BASE", "http://ml")
+    importlib.reload(url_builder)
+    url = url_builder.build_search_url("notebook", page=3)
+    # (3-1)*48 + 1 = 97
+    assert "_Desde_97" in url
+
+
+@pytest.mark.unit
+def test_offset_respeita_env_page_size(monkeypatch):
+    monkeypatch.setenv("URL_MLB_SEARCH_BASE", "http://ml")
+    monkeypatch.setenv("ML_PAGE_SIZE", "50")
+    importlib.reload(url_builder)
+    url = url_builder.build_search_url("notebook", page=2)
+    # (2-1)*50 + 1 = 51
+    assert "_Desde_51" in url
+    monkeypatch.delenv("ML_PAGE_SIZE", raising=False)
+    importlib.reload(url_builder)

--- a/tests/unit/test_update_service_protection.py
+++ b/tests/unit/test_update_service_protection.py
@@ -1,0 +1,75 @@
+"""Garante que a página de produto usa rate limiter, backoff e detecção
+de bloqueio unificada (ponto #3 da issue #52)."""
+import pytest
+
+from scrapper_mlb.product_page.service import update_service
+from tests.factories import FakeResponseFactory, ProductPageDataFactory
+
+
+@pytest.fixture
+def patch_build(mocker):
+    """Evita parsing/IO real do build_product_page."""
+    return mocker.patch.object(
+        update_service,
+        "build_product_page",
+        return_value=ProductPageDataFactory(),
+    )
+
+
+@pytest.mark.unit
+def test_resposta_valida_usa_rate_limiter_e_success(mocker, patch_build):
+    wait = mocker.patch.object(update_service.rate_limiter, "wait")
+    success = mocker.patch.object(update_service.backoff, "success")
+    error = mocker.patch.object(update_service.backoff, "error")
+    mocker.patch.object(
+        update_service.session, "get", return_value=FakeResponseFactory()
+    )
+
+    result = update_service._collect_once("http://x/MLB1#frag", produto_id=1)
+
+    assert result is not None
+    wait.assert_called_once()          # rate limiter aplicado antes do GET
+    success.assert_called_once()       # backoff resetado na resposta válida
+    error.assert_not_called()
+
+
+@pytest.mark.unit
+def test_pagina_de_bloqueio_dispara_backoff_error(mocker, patch_build):
+    mocker.patch.object(update_service.rate_limiter, "wait")
+    error = mocker.patch.object(update_service.backoff, "error")
+    blocked = FakeResponseFactory(text="<html>resolva o CAPTCHA</html>")
+    mocker.patch.object(update_service.session, "get", return_value=blocked)
+
+    result = update_service._collect_once("http://x/MLB1", produto_id=1)
+
+    assert result is None
+    error.assert_called_once()
+    patch_build.assert_not_called()    # nem tenta parsear página bloqueada
+
+
+@pytest.mark.unit
+def test_status_invalido_dispara_backoff_error(mocker, patch_build):
+    mocker.patch.object(update_service.rate_limiter, "wait")
+    error = mocker.patch.object(update_service.backoff, "error")
+    mocker.patch.object(
+        update_service.session,
+        "get",
+        return_value=FakeResponseFactory(status_code=503),
+    )
+
+    result = update_service._collect_once("http://x/MLB1", produto_id=1)
+
+    assert result is None
+    error.assert_called_once()
+
+
+@pytest.mark.unit
+def test_retry_usa_backoff_wait(mocker):
+    # _collect_once sempre falha -> retry deve usar backoff.wait (não sleep fixo)
+    mocker.patch.object(update_service, "_collect_once", return_value=None)
+    backoff_wait = mocker.patch.object(update_service.backoff, "wait")
+
+    result = update_service.collect_product_by_url("http://x", 1, retries=2)
+
+    assert result is None
+    assert backoff_wait.call_count == 2


### PR DESCRIPTION
Promove `dev` para `main`. 12 commits, 49 arquivos, +1735/−825.

Closes #52

## O que entra

**Hardening do scraping — os 11 pontos da issue #52**

| # | Problema | PR |
|---|---|---|
| 1 | Race condition furava o anti-ban | #53 |
| 2 | Quebra silenciosa de seletor CSS | #54 |
| 3 | Detecção de bloqueio duplicada e inconsistente | #55 |
| 4 | Arquivo de debug global com escrita concorrente | #58 |
| 5 | User-Agent estático, sem rotação | #58 |
| 6 | Paginação por offset fixo | #58 |
| 7 | `create_driver` duplicado | #56 |
| 8 | Path absoluto hardcoded no perfil do Chrome | #56 |
| 9 | `time.sleep` mágico em vez de `WebDriverWait` | #57 |
| 10 | Driver único em sessão longa | #57 |
| 11 | Acoplamento à UI PT-BR do linkbuilder | #60 |

**Frontend**

- Redesign dark premium, cobrindo home, página de produto e listagens (#59)
- **Volta do structured data JSON-LD na home** — `WebSite` + `ItemList`/`Product`/`Offer`

## O structured data

O commit `977e790` ("estilo refatorado", 21/02) apagou os dois blocos `ld+json` da home em `main`, derrubando `page.tsx` de ~300 para 224 linhas. Passou despercebido: nenhum teste cobre isso e o build continuava verde.

Resultado: o site está no ar desde fevereiro sem `ItemList`, que é justamente o schema que gera rich result de produto no Google. Para um comparador de preço, esse é o canal principal de tráfego orgânico.

O `dev` nunca perdeu o schema. Este PR devolve o bloco à `main`, combinado com as correções de tipagem que vieram depois.

## Testes

De 21 para **62 passando**.

Duas falhas seguem no vermelho, e são anteriores a este trabalho — verifiquei rodando a suíte na `main` antes de qualquer merge:

```
FAILED tests/unit/test_extractor_unit.py::TestExtractLinkUnit::test_link
FAILED tests/unit/test_models.py::TestBuildProductIntegration::test_build_product_from_real_html
```

Não são regressão deste PR. Ficam para um PR próprio.

## Verificação do frontend

```
npx tsc --noEmit  → exit 0
npx eslint src    → exit 0
npx next build    → ✓ 6/6 páginas, ItemList presente no HTML gerado
```

O build foi rodado apontando para a API morta de propósito, para confirmar que o prerender resiliente do #62 sobreviveu ao redesign. Sobreviveu — mas só depois de reaplicado: o redesign é de 28/06 e as correções de lint, tipagem e resiliência são de 29/06, então resolver o conflito pela versão do redesign revertia as três. Estão de volta.

## Merge

Usar **merge commit**, não squash. Os 8 commits abaixo já estão limpos e um por PR; squashar perderia a rastreabilidade de qual mudança fechou qual ponto da issue.