### PR TITLE
chore: unifica as identidades do historico com .mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,10 @@
+# Unifica as identidades usadas no historico do repo.
+# Sem isso, `git shortlog -sn` e `git log --author` contam a mesma pessoa
+# tres vezes, por causa da troca de git config entre maquinas e das edicoes
+# feitas pela interface web do GitHub, que assina com o e-mail noreply.
+
+Leandro Baldan <leandro.baldan.ferreira@gmail.com> TrveLeo <leandro.baldan.ferreira@gmail.com>
+Leandro Baldan <leandro.baldan.ferreira@gmail.com> TrveLeo <143330199+TrveLeo@users.noreply.github.com>
+Leandro Baldan <leandro.baldan.ferreira@gmail.com> Leandro Baldan <143330199+TrveLeo@users.noreply.github.com>
+
+Eduardo Coutinho Vicente <114628385+EduardoCoutinhoVicente@users.noreply.github.com>


### PR DESCRIPTION
`git shortlog -sne` contava a mesma pessoa quatro vezes:

```
284  TrveLeo <leandro.baldan.ferreira@gmail.com>
 49  Leandro Baldan <143330199+TrveLeo@users.noreply.github.com>
  3  Eduardo Coutinho Vicente <...>
  2  TrveLeo <143330199+TrveLeo@users.noreply.github.com>
```

A divergência vem da troca de `git config` entre máquinas e das edições feitas pela interface web do GitHub, que assinam com o e-mail `noreply`. Depois:

```
335  Leandro Baldan <leandro.baldan.ferreira@gmail.com>
  3  Eduardo Coutinho Vicente <...>
```

Nenhum commit é reescrito — `.mailmap` só afeta como o git exibe autoria.

> **Mergear depois do #65.** Como o #65 é `dev` → `main` e já está aprovado, qualquer commit que entre em `dev` antes dele passa a fazer parte daquele diff.