### PR TITLE
feat(api): protege rotas /twitter com API key e limita taxa do /redirect

### DIFF
--- a/api/core/security.py
+++ b/api/core/security.py
@@ -1,0 +1,77 @@
+"""
+Segurança da API: verificação de API key e rate-limit simples.
+
+O rate-limit é in-memory (por processo). Suficiente para deploy
+single-instance. Se a API rodar com múltiplos workers/réplicas,
+migrar para um store compartilhado (Redis).
+"""
+
+import time
+import threading
+from collections import defaultdict, deque
+
+from fastapi import Header, HTTPException, Request
+
+from api.core.settings import settings
+
+
+# =====================================================
+# API KEY (rotas sensíveis)
+# =====================================================
+
+def require_api_key(x_api_key: str | None = Header(default=None)) -> None:
+    """
+    Dependency FastAPI. Bloqueia se a API_KEY não estiver
+    configurada (fail-closed) ou se o header não bater.
+    """
+    if not settings.API_KEY:
+        raise HTTPException(
+            status_code=503,
+            detail="API_KEY não configurada no servidor.",
+        )
+
+    if x_api_key != settings.API_KEY:
+        raise HTTPException(
+            status_code=401,
+            detail="API key inválida ou ausente.",
+        )
+
+
+# =====================================================
+# RATE LIMIT (por IP, janela deslizante)
+# =====================================================
+
+_hits: dict[str, deque] = defaultdict(deque)
+_lock = threading.Lock()
+
+
+def rate_limit_redirect(request: Request) -> None:
+    """
+    Dependency FastAPI. Limita requisições por IP numa janela
+    deslizante. Configurável via REDIRECT_RATE_LIMIT / WINDOW.
+    """
+    limit = settings.REDIRECT_RATE_LIMIT
+    window = settings.REDIRECT_RATE_WINDOW
+
+    ip = request.client.host if request.client else "unknown"
+    now = time.monotonic()
+
+    with _lock:
+        bucket = _hits[ip]
+        while bucket and bucket[0] <= now - window:
+            bucket.popleft()
+
+        if len(bucket) >= limit:
+            raise HTTPException(
+                status_code=429,
+                detail="Muitas requisições. Tente novamente em instantes.",
+            )
+
+        bucket.append(now)
+
+        # Remove IPs ociosos pra _hits não crescer indefinidamente: a poda
+        # acima só roda pro IP da requisição atual, então um IP que nunca
+        # mais volta ficaria no dict para sempre.
+        cutoff = now - window
+        for stale_ip in [k for k, b in _hits.items() if not b or b[-1] <= cutoff]:
+            del _hits[stale_ip]

--- a/api/core/settings.py
+++ b/api/core/settings.py
@@ -4,10 +4,12 @@ from dotenv import load_dotenv
 
 ENVIRONMENT = os.getenv("ENVIRONMENT", "production")
 
-if ENVIRONMENT == "production":
-    load_dotenv(".env.prod")
-else:
-    load_dotenv(".env.dev")
+# Carrega o .env específico do ambiente, com fallback pro .env genérico.
+# Em produção o .env.prod costuma não existir, e sem o fallback as vars
+# ficavam todas em branco.
+_env_file = ".env.prod" if ENVIRONMENT == "production" else ".env.dev"
+load_dotenv(_env_file)
+load_dotenv(".env")
 
 
 class Settings:
@@ -15,6 +17,14 @@ class Settings:
     DEBUG: bool = os.getenv("DEBUG", "false").lower() == "true"
     LOG_LEVEL: str = os.getenv("LOG_LEVEL", "INFO")
     DATABASE_URL: str = os.getenv("DATABASE_URL")
+
+    # Chave das rotas sensíveis (geração de posts, etc).
+    # Se vazia, essas rotas ficam bloqueadas — fail-closed.
+    API_KEY: str = os.getenv("API_KEY", "")
+
+    # Rate-limit dos redirects: nº máx. de requisições por IP por janela.
+    REDIRECT_RATE_LIMIT: int = int(os.getenv("REDIRECT_RATE_LIMIT", "60"))
+    REDIRECT_RATE_WINDOW: int = int(os.getenv("REDIRECT_RATE_WINDOW", "60"))
 
 
 settings = Settings()

--- a/api/routers/redirect_router.py
+++ b/api/routers/redirect_router.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Depends, Request
 from fastapi.responses import RedirectResponse
 from sqlalchemy.orm import Session
-from sqlalchemy import text
+from api.core.security import rate_limit_redirect
 from api.services.redirect_service import RedirectService
 
 from api.deps import get_db
@@ -9,7 +9,10 @@ from api.deps import get_db
 router = APIRouter(tags=["redirect"])
 
 
-@router.get("/redirect/{produto_id}")
+@router.get(
+    "/redirect/{produto_id}",
+    dependencies=[Depends(rate_limit_redirect)],
+)
 def redirect_to_product(
     produto_id: int,
     request: Request,

--- a/api/routers/twitter_content.py
+++ b/api/routers/twitter_content.py
@@ -2,12 +2,18 @@ from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 from api.services.twiiter_daily_post import generate_daily_tweets_job
 
+from api.core.security import require_api_key
 from api.deps import get_db
 from api.services.deal_service import DealService
 from api.services.twitter_content_service import TwitterContentService
 
 
-router = APIRouter(prefix="/twitter", tags=["twitter"])
+# Rotas que disparam geração de posts e escrita no banco: exigem API key.
+router = APIRouter(
+    prefix="/twitter",
+    tags=["twitter"],
+    dependencies=[Depends(require_api_key)],
+)
 
 
 @router.get("/price-drop")

--- a/api/services/product_service.py
+++ b/api/services/product_service.py
@@ -143,8 +143,6 @@ class ProductService:
             LIMIT :limit OFFSET :offset
         """
 
-        print(query)
-
         rows = self.db.execute(text(query), params).mappings().all()
 
         # -------------------------------------------------


### PR DESCRIPTION
Segunda das três partes extraídas do **#51**.

## O problema

As rotas `/twitter/*` estão **abertas na internet hoje**. `/twitter/generate-daily` dispara geração de posts e escreve no banco — qualquer um que descobrisse a URL podia chamá-la em loop.

## `api/core/security.py`

**`require_api_key`** — header `X-API-Key`, *fail-closed*. Se `API_KEY` não estiver configurada no servidor a rota responde **503 em vez de liberar**, para que um deploy sem a variável não vire bypass silencioso.

**`rate_limit_redirect`** — janela deslizante por IP, in-memory com lock. O dict de buckets poda os IPs ociosos a cada chamada; sem isso cresceria sem limite, já que a poda por bucket só alcança o IP da requisição atual.

Limitação documentada no docstring: o limite é **por processo**. Com múltiplos workers ou réplicas o teto efetivo vira `limite × nº de processos`. Para deploy multi-instância isso precisa migrar para Redis.

## `settings`

Novas vars `API_KEY`, `REDIRECT_RATE_LIMIT`, `REDIRECT_RATE_WINDOW`.

O `load_dotenv` ganha fallback para o `.env` genérico — em produção o `.env.prod` costuma não existir e as vars ficavam todas em branco.

## Também

Remove um `print(query)` em `product_service` que jogava SQL cru no log a cada listagem de produtos.

## O que deixei de fora do #51

A mudança que dá default a `twitter_post_id`, `ip` e `user_agent` em `process_redirect`. Ela existia para acomodar a rota `/go`, que o #68 remove justamente por chamar o método sem esse argumento. Manter o parâmetro obrigatório é o que denuncia o erro em vez de escondê-lo.

## Verificação

Testado com `TestClient`:

| cenário | resultado |
|---|---|
| sem header | **401** |
| header errado | **401** |
| header correto | passa a auth |
| `API_KEY` vazia no servidor | **503** (fail-closed) |
| rate limit com `limite=3` | `[ok, ok, ok, 429, 429]` |

`pytest`: 62 passando (as 2 falhas são anteriores e independentes).

## Ordem

Independente do #68 — não há sobreposição de arquivos. Pode entrar em qualquer ordem.

Depois de mergear, **configurar `API_KEY` no ambiente da API**, senão as rotas `/twitter/*` respondem 503. É o comportamento pretendido, mas quebra o job diário se passar batido.