### PR TITLE
fix(test): corrige a fixture de HTML real e volta a rodar os integration

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -7,4 +7,8 @@ markers =
     
 pythonpath = .
 testpaths = tests
-addopts = -m "not integration" --cov=api --cov=scrapper_mlb --cov-report=term-missing --cov-report=xml
+# Os testes `integration` voltam a rodar por padrao. Eles foram excluidos
+# quando um deles quebrou; o efeito foi esconder a falha em vez de corrigi-la,
+# e o CI parou de avisar sobre mudanca de layout do Mercado Livre — que e
+# exatamente o que essa camada existe para pegar. Custam menos de um segundo.
+addopts = --cov=api --cov=scrapper_mlb --cov-report=term-missing --cov-report=xml

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,9 +29,22 @@ def soup(ml_html):
 
 @pytest.fixture(scope="session")
 def first_item(soup):
-    item = soup.select_one("li.ui-search-layout__item")
-    assert item is not None, "Nenhum item encontrado na página"
-    return item
+    """Primeiro item que é de fato um produto.
+
+    Os primeiros `li` da listagem costumam ser anúncios patrocinados: o href
+    aponta para `click1.mercadolivre.com.br/mclics/clicks/external`, não para
+    a página do produto. O `extract_link` os ignora de propósito, então pegar
+    `select_one` cru entregava um anúncio e fazia `build_product` levantar
+    ValueError — o código estava certo, a fixture é que não espelhava
+    produção.
+    """
+    from scrapper_mlb.services.extractors.link import extract_link
+
+    for item in soup.select("li.ui-search-layout__item"):
+        if extract_link(item):
+            return item
+
+    pytest.fail("Nenhum item com link de produto encontrado no fixture")
 
 
 @pytest.fixture


### PR DESCRIPTION
Fecha a pendência registrada no #71: `test_build_product_from_real_html` estava quebrado e foi **silenciado, não corrigido**. O `-m "not integration"` no `addopts` do `pytest.ini` o tirava da execução padrão, o CI parou de avisar, e a falha continuou lá.

## O código estava certo; a fixture é que não espelhava produção

`first_item` usava `select_one("li.ui-search-layout__item")`. Os primeiros `li` da listagem do Mercado Livre costumam ser **anúncios patrocinados** — o `href` aponta para `click1.mercadolivre.com.br/mclics/clicks/external`, não para a página do produto:

```
âncoras do primeiro item do fixture:
  https://click1.mercadolivre.com.br/mclics/clicks/external/MLB/count?a=0pdKAV...
  https://publicidade.mercadolivre.com.br
```

O `extract_link` ignora patrocinado de propósito, então `build_product` recebia `None` e levantava `ValueError`. Comportamento correto do código, teste mal montado.

A fixture passa a varrer os itens até achar o primeiro com link de produto válido — que é o que o scraper faz em produção.

## Os `integration` voltam a rodar

Excluí-los escondia justamente a camada que existe para pegar mudança de layout do ML. Custam menos de um segundo.

## Verificação

```
suite padrão: 164 passando, 29 pulados (os que exigem PostgreSQL)
```

Os 29 pulados são os marcados `api`, que precisam de Postgres — comportamento inalterado.