### PR TITLE
chore(deploy): blueprint do Render, liveness sem banco e .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,60 @@
+# Copie para `.env` e preencha. Nenhum valor real entra no repositório.
+#
+# O carregamento é em cascata: `.env.prod` ou `.env.dev` conforme ENVIRONMENT,
+# com o `.env` genérico como fallback (api/core/settings.py).
+
+# =========================
+# Ambiente
+# =========================
+ENVIRONMENT=development
+DEBUG=false
+LOG_LEVEL=INFO
+
+# =========================
+# Banco
+# =========================
+# Em produção, use o endpoint *pooled* do Neon — o host com `-pooler`.
+# A aplicação abre uma conexão por request e o endpoint direto estoura o limite.
+DATABASE_URL=postgresql+psycopg2://usuario:senha@localhost:5432/promoly
+
+# =========================
+# Segurança da API
+# =========================
+# Protege as rotas /twitter/*, que disparam geração de posts e escrevem no
+# banco. É fail-closed: com a variável vazia, essas rotas respondem 503 em vez
+# de liberar. Um deploy sem ela não vira bypass silencioso — mas também derruba
+# o job diário, então defina.
+API_KEY=
+
+# Rate limit do /redirect, por IP. O limite é por processo: com múltiplos
+# workers ou réplicas o teto efetivo vira limite × nº de processos, e aí
+# precisa migrar para Redis.
+REDIRECT_RATE_LIMIT=60
+REDIRECT_RATE_WINDOW=60
+
+# =========================
+# Scraper (Mercado Livre)
+# =========================
+URL_MLB_BASE=https://www.mercadolivre.com.br
+URL_MLB_SEARCH_BASE=https://lista.mercadolivre.com.br
+
+# Vazio = todas as categorias de scrapper_mlb/config.py.
+# Atenção: `database/seed_db.py` só semeia eletronicos, casa e pet — as demais
+# são puladas com aviso até o seed cobrir todas.
+SCRAPER_ENABLED_CATEGORIES=
+
+# Tamanho de página da listagem e dump de HTML para depuração.
+ML_PAGE_SIZE=50
+SCRAPER_DEBUG_HTML=false
+
+# =========================
+# Worker de afiliado (Selenium)
+# =========================
+# Perfil do Chrome. Fora do código desde o #56 — antes era um caminho absoluto
+# fixo que só existia na máquina de um dev.
+SELENIUM_PROFILE_DIR=
+SELENIUM_PROFILE_NAME=
+
+# Seletores do linkbuilder do Mercado Livre, desacoplados da UI em PT-BR (#60).
+LINKBUILDER_TEXTAREA_ID=url-0
+LINKBUILDER_GERAR_TEXTS=Gerar,Generate

--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -14,6 +14,9 @@ COPY database ./database
 
 ENV PYTHONPATH=/app
 
+# A porta vem do ambiente: Render, Fly e Cloud Run injetam $PORT e derrubam o
+# container se o processo escutar em outra. O fallback mantem `docker compose`
+# local funcionando sem passar nada.
 EXPOSE 8080
 
-CMD ["uvicorn", "api.main:app", "--host", "0.0.0.0", "--port", "8080", "--proxy-headers", "--forwarded-allow-ips", "*"]
+CMD ["sh", "-c", "uvicorn api.main:app --host 0.0.0.0 --port ${PORT:-8080} --proxy-headers --forwarded-allow-ips '*'"]

--- a/api/routers/health.py
+++ b/api/routers/health.py
@@ -8,6 +8,19 @@ from api.services.health_service import HealthService
 router = APIRouter(prefix="/health", tags=["health"])
 
 
+@router.get("/live")
+def liveness() -> dict:
+    """Prova de vida do processo. Nao toca no banco, de proposito.
+
+    O healthcheck do orquestrador precisa responder "o processo esta de pe",
+    nao "o banco esta acordado". Apontar o Render para `/health/` — que
+    consulta o pipeline — faria o servico ser marcado como nao saudavel toda
+    vez que o Neon suspendesse por inatividade, entrando em loop de restart
+    justamente quando ninguem esta usando.
+    """
+    return {"status": "ok"}
+
+
 @router.get(
     "/",
     response_model=list[HealthOut],

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,38 @@
+# Blueprint do Render — https://render.com/docs/blueprint-spec
+#
+# Só a API entra aqui. O front é Next.js e vive na Vercel; o scraper roda por
+# cron no GitHub Actions (.github/workflows/scraper.yml) e não precisa de
+# serviço no ar.
+#
+# O banco NÃO é declarado: o Postgres gratuito do Render expira em 30 dias.
+# `DATABASE_URL` aponta para o Neon, usando o endpoint *pooled* (host com
+# `-pooler`) — a aplicação abre uma conexão por request e o endpoint direto
+# estoura o limite.
+#
+# O healthCheckPath é `/health/live`, que não consulta o banco. Apontar para
+# `/health/` faria o serviço ser marcado como não saudável toda vez que o Neon
+# suspendesse por inatividade.
+
+services:
+  - type: web
+    name: promoly-api
+    runtime: docker
+    dockerfilePath: ./Dockerfile.api
+    plan: free
+    region: oregon
+    healthCheckPath: /health/live
+    autoDeployTrigger: commit
+    envVars:
+      # Definir no painel. Não versionar: são credenciais.
+      - key: DATABASE_URL
+        sync: false
+      # Sem esta chave as rotas /twitter/* respondem 503 — fail-closed
+      # proposital. Definir, senão o job diário de posts para.
+      - key: API_KEY
+        sync: false
+      - key: ENVIRONMENT
+        value: production
+      - key: REDIRECT_RATE_LIMIT
+        value: "60"
+      - key: REDIRECT_RATE_WINDOW
+        value: "60"


### PR DESCRIPTION
Fecha a configuração de deploy da API. Depois disso falta só criar as contas.

## Uma armadilha que teria causado loop de restart

`/health/` **consulta o banco** — devolve as últimas execuções do pipeline. Apontar o healthcheck do Render para lá faria o serviço ser marcado como não saudável toda vez que o Neon suspendesse por inatividade, entrando em loop de restart **justamente quando ninguém está usando**.

Novo `GET /health/live` responde só "o processo está de pé", sem tocar no banco. É para onde o `render.yaml` aponta.

## `$PORT` no `Dockerfile.api`

O `CMD` fixava 8080. Render, Fly e Cloud Run injetam `$PORT` e matam o container se o processo escutar em outra — subiria e morreria no healthcheck sem erro óbvio.

## `render.yaml`

Só a API. O front é Next.js e vive na Vercel; o scraper roda por cron no GitHub Actions (`.github/workflows/scraper.yml`) e não precisa de serviço no ar.

O banco fica de fora: o Postgres gratuito do Render expira em 30 dias e levaria a demonstração junto. `DATABASE_URL` aponta para o Neon, endpoint *pooled*.

## `.env.example`

**Não existia.** As 16 variáveis que o projeto lê estavam só espalhadas pelo código — inclusive a `API_KEY`, cuja ausência derruba o job diário de posts com 503 pelo fail-closed do #69.

Cada uma documentada com o porquê, incluindo as pegadinhas que já apareceram nesta limpeza:

- usar o endpoint **pooled** do Neon, porque a aplicação abre uma conexão por request
- o rate limit ser **por processo**, então multi-réplica precisa de Redis
- o `seed_db.py` cobrir só três das nove categorias

## Verificação

Imagem construída e executada com `PORT=9125` **e `DATABASE_URL` apontando para um banco inexistente**:

```
/health/live → 200 {"status":"ok"}
/docs        → 200
```

Esse é justamente o caso que o healthcheck precisa sobreviver.

`pytest`: 164 passando, 29 pulados.