### PR TITLE
fix(db): torna possivel criar o banco do zero

### DIFF
--- a/.github/workflows/db-setup.yml
+++ b/.github/workflows/db-setup.yml
@@ -24,6 +24,14 @@ jobs:
       - name: Instala dependencias
         run: pip install -r requirements.txt
 
+      # As migrations do Alembic cobrem so o incremento — subcategorias,
+      # twitter_posts, colunas novas. Nenhuma delas cria `categorias`,
+      # `produtos` ou `plataformas`: o schema base mora em schema_postgres.sql
+      # e nunca foi versionado como migration. Sem este passo, o
+      # `alembic upgrade head` num banco vazio quebra na primeira FK.
+      - name: Aplica o schema base (se o banco estiver vazio)
+        run: python scripts/bootstrap_schema.py
+
       - name: Aplica migrations
         run: alembic upgrade head
 

--- a/migrations/versions/dfc21bc27b06_add_performance_indexes_for_price_.py
+++ b/migrations/versions/dfc21bc27b06_add_performance_indexes_for_price_.py
@@ -52,13 +52,16 @@ def upgrade():
         unique=False
     )
 
-    # Produtos públicos
-    op.create_index(
-        "idx_produtos_publicos_id",
-        "produtos_publicos",
-        ["id"],
-        unique=False
-    )
+    # `produtos_publicos` é uma VIEW, e PostgreSQL não aceita índice em view
+    # comum — só em tabela ou view materializada. Esta migration nunca rodou
+    # contra um banco criado do zero; quebrava com:
+    #
+    #   UndefinedTable: relation "produtos_publicos" does not exist
+    #
+    # e, com a view já criada, quebraria de novo por tentar indexá-la.
+    #
+    # O índice também não faria diferença: a view resolve pelos índices das
+    # tabelas de base, e `produtos.id` já é chave primária.
 
 
 def downgrade():

--- a/schema_postgres.sql
+++ b/schema_postgres.sql
@@ -72,6 +72,11 @@ CREATE TABLE produto_categoria (
 
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
 
+    PRIMARY KEY (produto_id, categoria_id),
+
+    FOREIGN KEY (produto_id) REFERENCES produtos(id) ON DELETE CASCADE,
+    FOREIGN KEY (categoria_id) REFERENCES categorias(id) ON DELETE CASCADE
+);
 
 
 -- ========================
@@ -192,6 +197,39 @@ CREATE TABLE clicks (
     FOREIGN KEY (produto_id) REFERENCES produtos(id),
     FOREIGN KEY (plataforma_id) REFERENCES plataformas(id)
 );
+
+
+-- ========================
+-- VIEW PÚBLICA DE PRODUTOS
+-- ========================
+-- Só produtos ativos que já têm link de afiliado gerado. É a fonte de
+-- `api/services/product_service.py` — sem ela, /products quebra com
+-- UndefinedTable num banco recém-criado.
+CREATE VIEW produtos_publicos AS
+SELECT
+    p.id,
+    p.external_id,
+    p.plataforma_id,
+    p.titulo,
+    p.slug,
+    p.descricao,
+    p.preco,
+    p.avaliacao,
+    p.vendas,
+    p.imagem_url,
+    p.link_original,
+    p.status,
+    p.card_hash,
+    p.created_at,
+    p.updated_at,
+    la.url_afiliada
+FROM produtos p
+JOIN links_afiliados la
+    ON la.produto_id = p.id
+    AND la.status = 'ok'
+    AND la.url_afiliada IS NOT NULL
+    AND la.url_afiliada != ''
+WHERE p.status = 'ativo';
 
 -- ========================
 -- ÍNDICES

--- a/scripts/bootstrap_schema.py
+++ b/scripts/bootstrap_schema.py
@@ -1,0 +1,68 @@
+"""Aplica o schema base num banco vazio, antes das migrations.
+
+As migrations do Alembic cobrem só o incremento — subcategorias,
+twitter_posts, colunas novas. Nenhuma delas cria `categorias`, `produtos` ou
+`plataformas`: o schema base mora em `schema_postgres.sql` e nunca foi
+versionado como migration. Rodar `alembic upgrade head` num banco vazio
+quebra na primeira chave estrangeira:
+
+    UndefinedTable: relation "categorias" does not exist
+
+Este script fecha essa lacuna. É idempotente: se as tabelas já existem, não
+faz nada.
+
+Usa SQLAlchemy em vez de `psql` de propósito — a URL do projeto vem no
+formato `postgresql+psycopg2://`, que o psql não entende, e a forma de URL
+do psql se mostrou frágil com `sslmode` em ambientes diferentes.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+from sqlalchemy import create_engine, text
+
+RAIZ = Path(__file__).resolve().parent.parent
+SCHEMA = RAIZ / "schema_postgres.sql"
+
+
+def main() -> int:
+    url = os.getenv("DATABASE_URL")
+    if not url:
+        print("DATABASE_URL não definida", file=sys.stderr)
+        return 1
+
+    engine = create_engine(url)
+
+    with engine.begin() as conn:
+        ja_existe = conn.execute(
+            text("select to_regclass('public.categorias') is not null")
+        ).scalar()
+
+        if ja_existe:
+            print("schema base já aplicado, pulando")
+            return 0
+
+        print(f"banco vazio — aplicando {SCHEMA.name}")
+        # `exec_driver_sql` entrega o texto direto ao psycopg2, que executa
+        # múltiplos comandos numa tacada. Com `text()` o SQLAlchemy tenta
+        # interpretar o conteúdo — trata `:` como bind param e erra o limite
+        # entre statements.
+        conn.exec_driver_sql(SCHEMA.read_text(encoding="utf-8"))
+
+    with engine.connect() as conn:
+        total = conn.execute(
+            text(
+                "select count(*) from information_schema.tables "
+                "where table_schema = 'public'"
+            )
+        ).scalar()
+
+    print(f"schema aplicado: {total} tabelas")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Três bugs que só aparecem num banco novo. O banco antigo do Railway tinha o schema montado à mão ao longo do tempo, então nenhum deles nunca doeu — até agora, subindo contra um Neon vazio.

## 1. `CREATE TABLE produto_categoria` nunca fechava

```sql
CREATE TABLE produto_categoria (
    produto_id INTEGER NOT NULL,
    categoria_id INTEGER NOT NULL,
    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                          ← acabava aqui

-- ========================
-- HISTÓRICO DE PREÇO
CREATE TABLE produto_preco_historico (
```

Sem chave primária, sem as duas FKs, sem `);`. O Postgres quebrava com `syntax error at or near "CREATE"`. **O arquivo nunca foi aplicado com sucesso.** Restaurado a partir de `database/schema.sql`, que tem a versão completa.

## 2. Faltava a view `produtos_publicos`

Ela existia só em `tests/sql/schema_test.sql`. Mas `api/services/product_service.py` consulta essa view **em produção** — então `/products` respondia 500 com `UndefinedTable` em qualquer banco recém-criado.

## 3. Migration criava índice sobre uma view

```python
op.create_index("idx_produtos_publicos_id", "produtos_publicos", ["id"])
```

PostgreSQL não aceita índice em view comum, só em tabela ou view materializada. E não faria diferença: a view resolve pelos índices das tabelas de base, e `produtos.id` já é chave primária.

## `scripts/bootstrap_schema.py`

As migrations do Alembic cobrem só o incremento — subcategorias, twitter_posts, colunas novas. **Nenhuma cria as tabelas de base**, que moram em `schema_postgres.sql` e nunca foram versionadas como migration. Rodar `alembic upgrade head` num banco vazio quebrava na primeira FK.

O script fecha essa lacuna, é idempotente, e usa SQLAlchemy em vez de `psql` — a URL do projeto vem com prefixo `postgresql+psycopg2://`, que o psql não entende.

## Verificação

Contra o Neon, com o schema derrubado e recriado do zero:

```
bootstrap  → 11 tabelas
alembic    → 8 migrations aplicadas em sequência
seed_db    → categorias e plataformas
seed_subcat→ subcategorias
```

Na API em produção (`promoly-api.onrender.com`):

```
/products              → 200
/categories/sitemap    → 200
/health/               → 200   (toca o banco)
/twitter/price-drop    → 200   (com X-API-Key)
```

`pytest`: 164 passando, 29 pulados.