### PR TITLE
chore(scraper): liga o cron, uma vez por dia

### DIFF
--- a/.github/workflows/scraper.yml
+++ b/.github/workflows/scraper.yml
@@ -2,8 +2,13 @@ name: Scraper Mercado Livre
 
 on:
   schedule:
-    # 06:00 e 18:00 em America/Sao_Paulo (runner usa UTC, UTC-3)
-    - cron: "0 9,21 * * *"
+    # 06:00 em America/Sao_Paulo (runner usa UTC, UTC-3).
+    #
+    # Uma vez por dia, nao duas. Isto aqui e trafego automatizado contra site
+    # de terceiro, e o Mercado Livre bloqueia IP quando quer — metade das
+    # requisicoes e metade do risco. Para o que o projeto precisa mostrar,
+    # ter produto na tela, a diferenca entre 12h e 24h de defasagem e nenhuma.
+    - cron: "0 9 * * *"
   workflow_dispatch:
 
 # Substitui o flock do run_scrapping.sh: duas execucoes nunca se cruzam.


### PR DESCRIPTION
O agendador já estava configurado e ativo desde o #63. O que impedia era um kill-switch: `.pipeline_disabled`, criado em `a40ec4c` (fev/2026) como "feature flag for workers cron".

O guard do workflow honrava a flag corretamente — o run manual de hoje **passou verde sem executar nada**, só o checkout:

```
success  Verifica flag de desligamento
skipped  Run actions/setup-python@v5
skipped  Instala dependências
skipped  Roda scraper
```

## Frequência: de duas para uma por dia

Era `0 9,21 * * *` (6h e 18h). Passa a `0 9 * * *` (6h).

Isto é tráfego automatizado contra site de terceiro, e o Mercado Livre bloqueia IP quando quer. Metade das requisições, metade do risco. Para o que o projeto precisa mostrar — ter produto na tela — a diferença entre 12h e 24h de defasagem é nenhuma.

O scraper já tem rotação de User-Agent, rate limiter com lock e detecção de bloqueio unificada, tudo dos #53 a #58. Isso reduz o risco, não elimina.

## O kill-switch continua existindo

Commitar `.pipeline_disabled` de volta desliga tudo sem mexer no workflow. É o mecanismo que acabou de provar que funciona.

## Pré-requisitos

Já cadastrados no repositório:

| tipo | nome |
|---|---|
| secret | `DATABASE_URL` |
| variable | `URL_MLB_BASE` |
| variable | `SCRAPER_ENABLED_CATEGORIES` = `eletronicos,casa,pet` |

As categorias estão limitadas às três que o `database/seed_db.py` popula. As outras seis do `scrapper_mlb/config.py` sairiam com aviso de "categoria não encontrada" — é a lacuna que registrei no #71 e que continua aberta.