### PR TITLE
fix(scraper): passa URL_MLB_SEARCH_BASE e as vars opcionais no workflow

### DIFF
--- a/.github/workflows/scraper.yml
+++ b/.github/workflows/scraper.yml
@@ -50,6 +50,18 @@ jobs:
         if: steps.flag.outputs.enabled == 'true'
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
+
+          # Sao dois hosts diferentes: o catalogo fica em www e a busca em
+          # lista. Faltando URL_MLB_SEARCH_BASE, o url_builder levanta
+          # RuntimeError na primeira query.
           URL_MLB_BASE: ${{ vars.URL_MLB_BASE }}
+          URL_MLB_SEARCH_BASE: ${{ vars.URL_MLB_SEARCH_BASE }}
+
           SCRAPER_ENABLED_CATEGORIES: ${{ vars.SCRAPER_ENABLED_CATEGORIES }}
+
+          # Opcionais: o codigo tem default para as duas. Passam mesmo assim
+          # para que a configuracao efetiva fique visivel no log do run, em vez
+          # de escondida no fonte.
+          ML_PAGE_SIZE: ${{ vars.ML_PAGE_SIZE }}
+          SCRAPER_DEBUG_HTML: ${{ vars.SCRAPER_DEBUG_HTML }}
         run: python -m scrapper_mlb.main


### PR DESCRIPTION
O primeiro run real do scraper, depois de remover o kill-switch, quebrou em:

```
📦 Categoria: Eletrônicos
🔍 Buscando: fone bluetooth
RuntimeError: URL_MLB_SEARCH_BASE não definida no ambiente
```

O scraper usa **dois hosts** do Mercado Livre: o catálogo em `www` e a busca em `lista`. O workflow só passava `URL_MLB_BASE`, então o `url_builder` levantava `RuntimeError` na primeira query — depois de já ter conectado no banco e começado a percorrer as categorias.

Passa também `ML_PAGE_SIZE` e `SCRAPER_DEBUG_HTML`. As duas têm default no código e não eram a causa da falha, mas declarar deixa a configuração efetiva visível no log do run em vez de escondida no fonte.

A variable `URL_MLB_SEARCH_BASE` foi cadastrada no repositório apontando para `https://lista.mercadolivre.com.br`.