### PR TITLE
fix(scraper): fallback nas vars opcionais do workflow

### DIFF
--- a/.github/workflows/scraper.yml
+++ b/.github/workflows/scraper.yml
@@ -59,9 +59,12 @@ jobs:
 
           SCRAPER_ENABLED_CATEGORIES: ${{ vars.SCRAPER_ENABLED_CATEGORIES }}
 
-          # Opcionais: o codigo tem default para as duas. Passam mesmo assim
-          # para que a configuracao efetiva fique visivel no log do run, em vez
-          # de escondida no fonte.
-          ML_PAGE_SIZE: ${{ vars.ML_PAGE_SIZE }}
-          SCRAPER_DEBUG_HTML: ${{ vars.SCRAPER_DEBUG_HTML }}
+          # Opcionais, com fallback explicito na expressao.
+          #
+          # O default do `os.getenv(nome, padrao)` so vale quando a variavel
+          # esta AUSENTE. Passar `${{ vars.X }}` de uma variable inexistente
+          # define X como string vazia, que existe — e `int("")` estoura com
+          # ValueError. O `||` resolve no lado do Actions, antes de virar env.
+          ML_PAGE_SIZE: ${{ vars.ML_PAGE_SIZE || '48' }}
+          SCRAPER_DEBUG_HTML: ${{ vars.SCRAPER_DEBUG_HTML || 'false' }}
         run: python -m scrapper_mlb.main


### PR DESCRIPTION
Regressão que eu mesmo introduzi no #76, ao passar `ML_PAGE_SIZE` e `SCRAPER_DEBUG_HTML` "para deixar a configuração visível":

```
ML_PAGE_SIZE:
SCRAPER_DEBUG_HTML:
...
ValueError: invalid literal for int() with base 10: ''
```

O default de `os.getenv(nome, padrao)` **só vale quando a variável está ausente**. Passar `${{ vars.X }}` de uma repository variable inexistente define `X` como string vazia — que existe, então o default nunca entra, e `int("")` estoura já na importação do `url_builder`.

O `||` resolve do lado do Actions, antes de virar variável de ambiente. Mantém a visibilidade no log sem depender de a variable estar cadastrada.